### PR TITLE
Bugfix: Unsaved map symbology changes now update when editing an observation

### DIFF
--- a/Mage/ObservationAnnotation.swift
+++ b/Mage/ObservationAnnotation.swift
@@ -50,10 +50,18 @@ import DateTools
     
     @objc public convenience init(observation: Observation, location: CLLocationCoordinate2D) {
         self.init()
+      
         observationId = observation.remoteId
         if observationId == nil {
             self._observation = observation
         }
+      
+        // If observation is locally modified but not yet saved, annotation uses the modified copy.
+        if observation.isDirty {
+          observationId = nil
+          self._observation = observation
+        }
+      
         self.coordinate = location
         self.title = observation.primaryFeedFieldText
         if self.title == nil || self.title.count == 0 {

--- a/MageTests/Map/ObservationAnnotationTests.swift
+++ b/MageTests/Map/ObservationAnnotationTests.swift
@@ -195,6 +195,58 @@ class ObservationAnnotationTests: KIFSpec {
                 expect(annotationView.centerOffset.x).to(equal(0))
                 expect(annotationView.centerOffset.y).to(equal(0))
             }
+          
+           it("should init with the observation id and not an _observation reference if has a remote id and not dirty") {
+              let iconPath = "\(getDocumentsDirectory())/events/icons-1/icons/26/Hi/icon.png"
+              
+              do {
+                 try FileManager.default.createDirectory(at: URL(fileURLWithPath: iconPath).deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                 let image: UIImage = UIImage(named: "marker")!
+                 FileManager.default.createFile(atPath: iconPath, contents: image.pngData()!, attributes: nil)
+              }
+              
+              var formsJson = getFormsJsonWithExtraFields()
+              
+              formsJson[0]["primaryField"] = "testfield";
+              formsJson[0]["primaryFeedField"] = "testfield";
+              
+              MageCoreDataFixtures.addEventFromJson(remoteId: 1, name: "Event", formsJson: formsJson)
+              
+              let observation = ObservationBuilder.createPointObservation(eventId:1);
+              observation.remoteId = "1"
+              observation.dirty = false
+
+              let annotation = ObservationAnnotation(observation: observation, location: observation.location!.coordinate)
+              expect(annotation.observationId).to(be(observation.remoteId))
+              
+              print(annotation.observation)
+              expect(annotation._observation).to(beNil())
+           }
+        
+           
+           it("should init with the observation reference and not an id if the observation is dirty") {
+              let iconPath = "\(getDocumentsDirectory())/events/icons-1/icons/26/Hi/icon.png"
+              
+              do {
+                 try FileManager.default.createDirectory(at: URL(fileURLWithPath: iconPath).deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                 let image: UIImage = UIImage(named: "marker")!
+                 FileManager.default.createFile(atPath: iconPath, contents: image.pngData()!, attributes: nil)
+              }
+              
+              var formsJson = getFormsJsonWithExtraFields()
+              formsJson[0]["primaryField"] = "testfield";
+              formsJson[0]["primaryFeedField"] = "testfield";
+              
+              MageCoreDataFixtures.addEventFromJson(remoteId: 1, name: "Event", formsJson: formsJson)
+              
+              let observation = ObservationBuilder.createPointObservation(eventId:1);
+              observation.remoteId = "1"
+              observation.dirty = true
+               
+              let annotation = ObservationAnnotation(observation: observation, location: observation.location!.coordinate)
+              expect(annotation.observationId).to(beNil())
+              expect(annotation.observation).to(beIdenticalTo(observation))
+           }
         }
     }
 }


### PR DESCRIPTION
Bugfix: Unsaved map symbology changes now update when editing an observation

Form changes that affect map symbology were NOT reflected on the map card when editing. This breaks feature parity with mage-android 7.2.2 which behaved correctly. Observation annotations initialized with a dirty observation now reference that copy rather than the "original" via id, so they now show on the map card (not saved unless the user chooses so). Added 2 tests to verify correct behavior.