### PR TITLE
DMS teleport bug

### DIFF
--- a/MAGE.xcodeproj/project.pbxproj
+++ b/MAGE.xcodeproj/project.pbxproj
@@ -4015,7 +4015,7 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/zxcvbn-ios/zxcvbn_ios.framework/Headers\"",
 				);
 				INFOPLIST_FILE = MAGETests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = (
@@ -4064,7 +4064,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = MAGETests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (

--- a/Mage/GeometryEditViewController.m
+++ b/Mage/GeometryEditViewController.m
@@ -763,7 +763,7 @@ static NSString *garsTitle = @"GARS";
 }
 
 - (void)fieldValueChangedWithCoordinate:(CLLocationDegrees)coordinate field:(CoordinateField *)field {
-    if (self.fieldTypeTabs.selectedItem.tag == 2) {
+    if (self.fieldTypeTabs.selectedItem.tag == 2 && field.isEditing) {
         [self onLatLonTextChanged];
     }
 }

--- a/Mage/GeometryEditViewController.m
+++ b/Mage/GeometryEditViewController.m
@@ -65,7 +65,6 @@ static NSString *garsTitle = @"GARS";
 @property (nonatomic) double lastAnnotationSelectedTime;
 @property (nonatomic, strong) Observation *observation;
 @property (strong, nonatomic) GPKGMapPoint *selectedMapPoint;
-@property (nonatomic) BOOL isObservationGeometry;
 @property (strong, nonatomic) id<MDCContainerScheming> scheme;
 
 @property (strong, nonatomic) MDCFloatingButton *searchButton;
@@ -841,7 +840,6 @@ static NSString *garsTitle = @"GARS";
         
         [self updateLocationTextWithCoordinate:coordinate ignoreSelected:YES];
     }
-    
 }
 
 - (void) mapView: (MKMapView *) mapView didSelectAnnotationView: (MKAnnotationView *) view {
@@ -932,20 +930,13 @@ static NSString *garsTitle = @"GARS";
 - (void) updateGeometry {    
     SFGeometry *geometry = nil;
     if (self.geometry != nil) {
-        if (self.shapeType == SF_POINT && self.isObservationGeometry) {
-            MapAnnotationObservation *mapAnnotationObservation = (MapAnnotationObservation *)self.mapObservation;
-            ObservationAnnotation *annotation = mapAnnotationObservation.annotation;
-            geometry = [SFPoint pointWithXValue:annotation.coordinate.longitude andYValue:annotation.coordinate.latitude];
-        } else {
-            @try {
-                geometry = [self.shapeConverter toGeometryFromMapShape:[self mapShapePoints].shape];
-            }
-            @catch (NSException* e) {
-                NSLog(@"Invalid Geometry");
-            }
+        @try {
+            geometry = [self.shapeConverter toGeometryFromMapShape:[self mapShapePoints].shape];
+        }
+        @catch (NSException* e) {
+            NSLog(@"Invalid Geometry");
         }
     }
-    
     [self.coordinator updateGeometry:geometry];
 }
 
@@ -1265,36 +1256,25 @@ static NSString *garsTitle = @"GARS";
 -(void) addMapShape: (SFGeometry *) geometry{
     self.geometry = geometry;
     CLLocationCoordinate2D previousSelectedPointLocation = kCLLocationCoordinate2DInvalid;
-    if(self.selectedMapPoint != nil){
+    if (self.selectedMapPoint != nil) {
         previousSelectedPointLocation = self.selectedMapPoint.coordinate;
         self.selectedMapPoint = nil;
         [self clearRectangleCorners];
     }
-    if(self.mapObservation != nil){
+    if (self.mapObservation != nil) {
         [self.mapObservation removeFromMapView:self.map];
         self.mapObservation = nil;
     }
     if (geometry.geometryType == SF_POINT) {
-        if (self.isObservationGeometry) {
-            self.mapObservation = [self.observationManager addToMapWithObservation:self.observation withGeometry:geometry];
-            MapAnnotationObservation *mapAnnotationObservation = (MapAnnotationObservation *)self.mapObservation;
-            mapAnnotationObservation.annotation.accessibilityLabel = @"point edit annotation";
-            [self updateLocationTextWithAnnotationObservation:mapAnnotationObservation];
-            [self selectAnnotation:mapAnnotationObservation.annotation];
-            
-        } else {
-            
-            GPKGMapShape *shape = [self.shapeConverter toShapeWithGeometry:geometry];
-            GPKGMapPointOptions *options = [[GPKGMapPointOptions alloc] init];
-            options.image = self.coordinator.pinImage;
-            GPKGMapShapePoints *shapePoints = [self.shapeConverter addMapShape:shape asPointsToMapView:self.map withPointOptions:options andPolylinePointOptions:nil andPolygonPointOptions:nil andPolygonPointHoleOptions:nil andPolylineOptions:nil andPolygonOptions:nil];
-            self.mapObservation = [[MapShapePointsObservation alloc] initWithObservation:self.observation andShapePoints:shapePoints];
-            SFPoint *point = (SFPoint *)geometry;
-            [self updateLocationTextWithLatitude:[point.y doubleValue] andLongitude:[point.x doubleValue]];
-            shapePoints.shape.shape.accessibilityLabel = @"point edit annotation";
-            [self selectAnnotation:shapePoints.shape.shape];
-        }
-        
+        GPKGMapShape *shape = [self.shapeConverter toShapeWithGeometry:geometry];
+        GPKGMapPointOptions *options = [[GPKGMapPointOptions alloc] init];
+        options.image = self.coordinator.pinImage;
+        GPKGMapShapePoints *shapePoints = [self.shapeConverter addMapShape:shape asPointsToMapView:self.map withPointOptions:options andPolylinePointOptions:nil andPolygonPointOptions:nil andPolygonPointHoleOptions:nil andPolylineOptions:nil andPolygonOptions:nil];
+        self.mapObservation = [[MapShapePointsObservation alloc] initWithObservation:self.observation andShapePoints:shapePoints];
+        SFPoint *point = (SFPoint *)geometry;
+        [self updateLocationTextWithLatitude:[point.y doubleValue] andLongitude:[point.x doubleValue]];
+        shapePoints.shape.shape.accessibilityLabel = @"point edit annotation";
+        [self selectAnnotation:shapePoints.shape.shape];
     } else {
         GPKGMapShape *shape = [self.shapeConverter toShapeWithGeometry:geometry];
         GPKGMapPointOptions *options = [[GPKGMapPointOptions alloc] init];

--- a/Mage/LocationUtilities.swift
+++ b/Mage/LocationUtilities.swift
@@ -222,7 +222,7 @@ public class LocationUtilities: NSObject {
         return true
     }
     
-    // attempts to parse what was passed in to DDD° MM' SS.sss" (NS) or returns "" if unparsable
+    // attempts to parse the input string to DDD° MM' SS.sss" (NS) or returns "" if unparsable
     @objc public static func parseToDMSString(_ string: String?, addDirection: Bool = false, latitude: Bool = false) -> String? {
         guard let string = string else {
             return nil
@@ -284,7 +284,7 @@ public class LocationUtilities: NSObject {
             latDegrees += 1
             latMinutes = 0
         }
-        return "\(abs(latDegrees))° \(nf.string(for: latMinutes) ?? "")\' \(nf.string(for: latSeconds) ?? "")\" \(latDegrees >= 0 ? "N" : "S")"
+        return "\(abs(latDegrees))° \(nf.string(for: latMinutes) ?? "")\' \(nf.string(for: latSeconds) ?? "")\" \(coordinate >= 0 ? "N" : "S")"
     }
     
     @objc public static func longitudeDMSString(coordinate: CLLocationDegrees) -> String {
@@ -303,6 +303,6 @@ public class LocationUtilities: NSObject {
             lonDegrees += 1
             lonMinutes = 0
         }
-        return "\(abs(lonDegrees))° \(nf.string(for: lonMinutes) ?? "")\' \(nf.string(for: lonSeconds) ?? "")\" \(lonDegrees >= 0 ? "E" : "W")"
+        return "\(abs(lonDegrees))° \(nf.string(for: lonMinutes) ?? "")\' \(nf.string(for: lonSeconds) ?? "")\" \(coordinate >= 0 ? "E" : "W")"
     }
 }

--- a/MageTests/Categories/LocationUtilitiesTests.swift
+++ b/MageTests/Categories/LocationUtilitiesTests.swift
@@ -18,7 +18,7 @@ class LocationUtilitiesTests: QuickSpec {
     override func spec() {
         
         describe("LocationUtilitiesTests Tests") {
-            
+
             it("should display the coordinate") {
                 UserDefaults.standard.locationDisplay = .latlng
                 
@@ -450,6 +450,10 @@ class LocationUtilitiesTests: QuickSpec {
                 expect(LocationUtilities.latitudeDMSString(coordinate:coordinate)).to(equal("11° 06' 00\" N"))
                 coordinate = CLLocationDegrees(-11.1)
                 expect(LocationUtilities.latitudeDMSString(coordinate:coordinate)).to(equal("11° 06' 00\" S"))
+                coordinate = CLLocationDegrees(0.125)
+                expect(LocationUtilities.latitudeDMSString(coordinate: coordinate)).to(equal("0° 07' 30\" N"))
+                coordinate = CLLocationDegrees(-0.125)
+                expect(LocationUtilities.latitudeDMSString(coordinate: coordinate)).to(equal("0° 07' 30\" S"))
             }
             
             it("should return a longitude dms string") {
@@ -457,9 +461,12 @@ class LocationUtilitiesTests: QuickSpec {
                 expect(LocationUtilities.longitudeDMSString(coordinate:coordinate)).to(equal("11° 06' 00\" E"))
                 coordinate = CLLocationDegrees(-11.1)
                 expect(LocationUtilities.longitudeDMSString(coordinate:coordinate)).to(equal("11° 06' 00\" W"))
-                
                 coordinate = CLLocationDegrees(18.077251)
                 expect(LocationUtilities.longitudeDMSString(coordinate:coordinate)).to(equal("18° 04' 38\" E"))
+                coordinate = CLLocationDegrees(0.125)
+                expect(LocationUtilities.longitudeDMSString(coordinate: coordinate)).to(equal("0° 07' 30\" E"))
+                coordinate = CLLocationDegrees(-0.125)
+                expect(LocationUtilities.longitudeDMSString(coordinate: coordinate)).to(equal("0° 07' 30\" W"))
             }
         }
     }


### PR DESCRIPTION
When editing an observation's location between 0 and -1 degrees latitude with the DMS coordinate format tab active, the observation pin would jump to the positive side of the equator.  This PR fixes that behavior.  Additionally, this PR prevents the map from constantly moving to center on the observation location pin when dragging and dropping the pin, which only occurred when the DMS tab was active and was an annoying UX.