### PR TITLE
video attachment metadata discrepancy

### DIFF
--- a/Mage/AttachmentCreationCoordinator.swift
+++ b/Mage/AttachmentCreationCoordinator.swift
@@ -347,7 +347,6 @@ extension AttachmentCreationCoordinator: PHPickerViewControllerDelegate {
                         return
                     }
                 }
-                
                 // otherwise it should be a movie
                 if utType.conforms(to: .movie), let assetIdentifier = result.assetIdentifier {
                     let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [assetIdentifier], options: nil)

--- a/Mage/AttachmentCreationCoordinator.swift
+++ b/Mage/AttachmentCreationCoordinator.swift
@@ -246,6 +246,9 @@ extension AttachmentCreationCoordinator: PHPickerViewControllerDelegate {
                 galleryPermissionDenied()
                 return
             }
+            guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                return
+            }
             let dateFormatter = DateFormatter();
             dateFormatter.dateFormat = "yyyyMMdd_HHmmss";
 

--- a/Mage/AttachmentCreationCoordinator.swift
+++ b/Mage/AttachmentCreationCoordinator.swift
@@ -199,11 +199,11 @@ extension AttachmentCreationCoordinator: PHPickerViewControllerDelegate {
                 galleryPermissionDenied()
                 return
             }
-            let dateFormatter = DateFormatter();
-            dateFormatter.dateFormat = "yyyyMMdd_HHmmss";
             guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
                 return
             }
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyyMMdd_HHmmss"
             let attachmentsDirectory = documentsDirectory.appendingPathComponent("attachments")
             let manager = PHImageManager.default()
             let requestOptions = PHImageRequestOptions()
@@ -249,9 +249,10 @@ extension AttachmentCreationCoordinator: PHPickerViewControllerDelegate {
             guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
                 return
             }
-            let dateFormatter = DateFormatter();
-            dateFormatter.dateFormat = "yyyyMMdd_HHmmss";
-
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyyMMdd_HHmmss"
+            let attachmentsDirectory = documentsDirectory.appendingPathComponent("attachments")
+            let fileToWriteTo = attachmentsDirectory.appendingPathComponent("MAGE_\(dateFormatter.string(from: Date())).mp4")
             let manager = PHImageManager.default()
             let requestOptions = PHVideoRequestOptions()
             requestOptions.deliveryMode = .highQualityFormat
@@ -261,55 +262,47 @@ extension AttachmentCreationCoordinator: PHPickerViewControllerDelegate {
                 guard let avAsset = avAsset else {
                     return
                 }
-
                 let videoQuality: String = self.videoUploadQuality();
-                print("video quality \(videoQuality)")
                 let compatiblePresets: [String] = AVAssetExportSession.exportPresets(compatibleWith: avAsset);
-                if (compatiblePresets.contains(videoQuality)) {
-                    guard let exportSession: AVAssetExportSession = AVAssetExportSession(asset: avAsset, presetName: videoQuality) else {
-                        print("Export session not created")
-                        return
-                    }
-                    let fileType = utType?.preferredFilenameExtension ?? "mp4"
-                    let mimeType = utType?.preferredMIMEType ?? "video/mp4"
-                    guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                        return;
-                    }
-                    let attachmentsDirectory = documentsDirectory.appendingPathComponent("attachments")
-                    let fileToWriteTo = attachmentsDirectory.appendingPathComponent("MAGE_\(dateFormatter.string(from: Date())).\(fileType)");
-
-                    do {
-                        try FileManager.default.createDirectory(at: fileToWriteTo.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: [.protectionKey : FileProtectionType.complete]);
-                        exportSession.outputURL = fileToWriteTo;
-                        exportSession.outputFileType = .mp4;
-                        print("exporting async")
-                        exportSession.exportAsynchronously {
-                            print("export session status \(exportSession.status)")
-                            switch (exportSession.status) {
-                            case .completed:
-                                print("Export complete")
-                                self.addAttachmentForSaving(location: fileToWriteTo, contentType: mimeType)
-                            case .failed:
-                                print("Export Failed: \(String(describing: exportSession.error?.localizedDescription))")
-                            case .cancelled:
-                                print("Export cancelled");
-                            case .unknown:
-                                print("Unknown")
-                            case .waiting:
-                                print("Waiting")
-                            case .exporting:
-                                print("Exporting")
-                            @unknown default:
-                                print("Unknown")
-                            }
-                        }
-                    } catch {
-                        print("Error creating directory path \(fileToWriteTo.deletingLastPathComponent()): \(error)")
+                guard compatiblePresets.contains(videoQuality) else {
+                    return
+                }
+                guard let exportSession: AVAssetExportSession = AVAssetExportSession(asset: avAsset, presetName: videoQuality) else {
+                    print("Export session not created")
+                    return
+                }
+                do {
+                    try FileManager.default.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true, attributes: [.protectionKey : FileProtectionType.complete]);
+                }
+                catch {
+                    print("error creating directory \(attachmentsDirectory) to export attachment video", error)
+                    return
+                }
+                exportSession.outputURL = fileToWriteTo;
+                exportSession.outputFileType = .mp4;
+                print("exporting async")
+                exportSession.exportAsynchronously {
+                    print("export session status \(exportSession.status)")
+                    switch (exportSession.status) {
+                    case .completed:
+                        print("Export complete")
+                        self.addAttachmentForSaving(location: fileToWriteTo, contentType: "video/mp4")
+                    case .failed:
+                        print("Export Failed: \(String(describing: exportSession.error?.localizedDescription))")
+                    case .cancelled:
+                        print("Export cancelled");
+                    case .unknown:
+                        print("Unknown")
+                    case .waiting:
+                        print("Waiting")
+                    case .exporting:
+                        print("Exporting")
+                    @unknown default:
+                        print("Unknown")
                     }
                 }
             }
         }
-    
     }
     
     func galleryPermissionDenied() {

--- a/Mage/Mixins/FeedsMap.swift
+++ b/Mage/Mixins/FeedsMap.swift
@@ -169,7 +169,6 @@ class FeedsMapMixin: NSObject, MapMixin {
 extension FeedsMapMixin : FeedItemDelegate {
     func addFeedItem(_ feedItem: FeedItem) {
         if (feedItem.isMappable) {
-            print("add feed item at \(feedItem.coordinate)")
             feedsMap.mapView?.addAnnotation(feedItem);
         }
     }

--- a/MageTests/Observation/Attachment/AttachmentCreationCoordinatorTests.swift
+++ b/MageTests/Observation/Attachment/AttachmentCreationCoordinatorTests.swift
@@ -132,7 +132,7 @@ class AttachmentCreationCoordinatorTests: KIFSpec {
 
                 // there is no way to call the delegate method picker(picker:didFinishPicking:) because
                 // the sdk provides no accessible constructor for the PHPickerResult struct. thanks, apple
-                attachmentCreationCoordinator.handlePhoto(photo: selectedAsset, utType: UTType.png)
+                attachmentCreationCoordinator.handlePhoto(selectedAsset: selectedAsset, utType: UTType.png)
                 self.wait(for: [ delegate.attachmentCreatedCalled ], timeout: 5.0)
 
                 let createdAttachment: Attachment = delegate.createdAttachment!


### PR DESCRIPTION
Properly annotate all video attachments selected from the gallery as `video/mp4` with a `.mp4` file extension.  Previously, the app improperly retained the original file extension and media type despite always transcoding videos to MP4 prior to upload.