### PR TITLE
attachment cell crash

### DIFF
--- a/Mage/AttachmentCell.swift
+++ b/Mage/AttachmentCell.swift
@@ -65,7 +65,7 @@ import Kingfisher
         self.button = button
         self.imageView.tintColor = scheme?.colorScheme.onBackgroundColor.withAlphaComponent(0.4)
         self.imageView.contentMode = .scaleAspectFill
-        self.imageView.kf.indicatorType = .activity
+        self.imageView.kf.indicatorType = .none
         guard let contentType = newAttachment["contentType"] as? String, let localPath = newAttachment["localPath"] as? String else {
             return
         }
@@ -118,7 +118,7 @@ import Kingfisher
     @objc public func setImage(attachment: Attachment, formatName:NSString, button: MDCFloatingButton? = nil, scheme: MDCContainerScheming? = nil) {
         layoutSubviews();
         self.button = button;
-        self.imageView.kf.indicatorType = .activity;
+        self.imageView.kf.indicatorType = .none;
         self.imageView.tintColor = scheme?.colorScheme.onBackgroundColor.withAlphaComponent(0.4);
         if (attachment.contentType?.hasPrefix("image") ?? false) {
             self.imageView.setAttachment(attachment: attachment);


### PR DESCRIPTION
This PR has a fix for a crash that happens occasionally when adding and removing attachments in the observation edit view.  The crash happens because the Kingfisher library calls `stopAnimating()` on the activity indicator of an attachment thumbnail image view in a collection view cell while the collection view is recycling cells.