### PR TITLE
MAGE-1509 Fix Server URL issue when switching between servers

### DIFF
--- a/Mage/MageAppCoordinator.m
+++ b/Mage/MageAppCoordinator.m
@@ -109,6 +109,9 @@
 
 - (void) setServerURLWithUrl:(NSURL *)url {
     __weak __typeof__(self) weakSelf = self;
+    
+    [[UserUtility singleton] expireToken]; // Clear any previous authentication methods when switching servers
+    
     [MageServer serverWithUrl:url success:^(MageServer *mageServer) {
         [MageInitializer clearServerSpecificData];
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/sdk/Networking/MageSessionManager.m
+++ b/sdk/Networking/MageSessionManager.m
@@ -89,7 +89,11 @@ static NSDictionary<NSNumber *, NSArray<NSNumber *> *> * eventTasks;
 }
 
 -(void) setTokenInRequestSerializer: (AFHTTPRequestSerializer *) requestSerializer{
-    [requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", _token] forHTTPHeaderField:@"Authorization"];
+    if (_token != nil) {
+        [requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", _token] forHTTPHeaderField:@"Authorization"];
+    } else { // Clear authorization from http headers
+        [requestSerializer setValue:nil forHTTPHeaderField:@"Authorization"];
+    }
 }
 
 -(AFHTTPRequestSerializer *) httpRequestSerializer{


### PR DESCRIPTION
Fixes an issue where you cannot enter the URL for a different server after you have already logged into and out of another server. You have to quit the app before it lets you change servers.

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1509
<img width="1585" alt="401 error" src="https://github.com/user-attachments/assets/20e4ec0c-8a7e-4d91-86ae-3532378a5e3a" />

![failed to change servers](https://github.com/user-attachments/assets/66ccb0e1-0646-4071-97dc-c061f588b36e)

