### PR TITLE
Core Data Concurrency Fixes

### DIFF
--- a/Mage/CoreData/Event.swift
+++ b/Mage/CoreData/Event.swift
@@ -106,23 +106,14 @@ import CoreData
     }
     
     @objc public static func getCurrentEvent(context: NSManagedObjectContext) -> Event? {
-        @Injected(\.nsManagedObjectContext)
-        var context: NSManagedObjectContext?
-        
-        if let context = context, let currentEventId = Server.currentEventId() {
+        if let currentEventId = Server.currentEventId() {
             return context.fetchFirst(Event.self, key: EventKey.remoteId.key, value: currentEventId)
         }
         return nil;
     }
     
     @objc public static func getEvent(eventId: NSNumber, context: NSManagedObjectContext) -> Event? {
-        @Injected(\.nsManagedObjectContext)
-        var context: NSManagedObjectContext?
-        
-        if let context = context {
-            return context.fetchFirst(Event.self, key: EventKey.remoteId.key, value: eventId)
-        }
-        return nil;
+        return context.fetchFirst(Event.self, key: EventKey.remoteId.key, value: eventId)
     }
     
     @objc public static func caseInsensitiveSortFetchAll(sortTerm: String?, ascending: Bool, predicate: NSPredicate?, groupBy: String?, context: NSManagedObjectContext) -> NSFetchedResultsController<Event>? {

--- a/Mage/CoreData/GPSLocation.swift
+++ b/Mage/CoreData/GPSLocation.swift
@@ -48,7 +48,7 @@ import SimpleFeatures
         }
     }
     
-    @objc public static func gpsLocation(location: CLLocation, context: NSManagedObjectContext) -> GPSLocation? {
+    @objc public static func gpsLocation(location: CLLocation, context: NSManagedObjectContext) -> GPSLocation {
         let gpsLocation = GPSLocation(context: context)
         
         let device = UIDevice.current

--- a/Mage/CoreData/GPSLocation.swift
+++ b/Mage/CoreData/GPSLocation.swift
@@ -49,18 +49,7 @@ import SimpleFeatures
     }
     
     @objc public static func gpsLocation(location: CLLocation, context: NSManagedObjectContext) -> GPSLocation? {
-        var gpsLocation: GPSLocation? {
-            @Injected(\.nsManagedObjectContext)
-            var context: NSManagedObjectContext?
-            if let context = context {
-                return GPSLocation(context: context)
-            }
-            return nil
-        }
-        
-        guard let gpsLocation = gpsLocation else {
-            return nil;
-        }
+        let gpsLocation = GPSLocation(context: context)
         
         let device = UIDevice.current
         device.isBatteryMonitoringEnabled = true;

--- a/MageTests/MageCoreDataFixtures.swift
+++ b/MageTests/MageCoreDataFixtures.swift
@@ -128,9 +128,9 @@ class MageCoreDataFixtures {
         return context.performAndWait({
             let location: CLLocation = location ?? CLLocation(coordinate: CLLocationCoordinate2D(latitude: 40.1085, longitude: -104.3678), altitude: 2600, horizontalAccuracy: 4.2, verticalAccuracy: 3.1, timestamp: Date(timeIntervalSince1970: 5));
             
-            let gpsLocation = GPSLocation.gpsLocation(location: location, context: context);
+            let gpsLocation = GPSLocation.gpsLocation(location: location, context: context)
             
-            try? context.obtainPermanentIDs(for: [gpsLocation!])
+            try? context.obtainPermanentIDs(for: [gpsLocation])
             try? context.save()
         })
     }


### PR DESCRIPTION
Fixes issues related to the wrong context being used by the event and location logic.

Tested and identified crash prone logic using the Run launch argument: `-com.apple.CoreData.ConcurrencyDebug 1`.

Relates to: https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1512