### PR TITLE
1556 - Observation thumbnails not loading

### DIFF
--- a/Mage/UI/Attachment/AttachmentPreviewView.swift
+++ b/Mage/UI/Attachment/AttachmentPreviewView.swift
@@ -22,7 +22,8 @@ struct AttachmentPreviewView: View {
                 )
                 .requestModifier(ImageCacheProvider.shared.accessTokenModifier)
                 .cacheOriginalImage()
-                .onlyFromCache(DataConnectionUtilities.shouldFetchAttachments())
+                // .all == download freely, .wifi == download once selected, .none == don't download unless specified
+                .onlyFromCache(!DataConnectionUtilities.shouldFetchAttachments())
                 .placeholder {
                     Image("observations")
                         .symbolRenderingMode(.monochrome)

--- a/Mage/UI/Attachment/AttachmentPreviewView.swift
+++ b/Mage/UI/Attachment/AttachmentPreviewView.swift
@@ -22,7 +22,6 @@ struct AttachmentPreviewView: View {
                 )
                 .requestModifier(ImageCacheProvider.shared.accessTokenModifier)
                 .cacheOriginalImage()
-                // .all == download freely, .wifi == download once selected, .none == don't download unless specified
                 .onlyFromCache(!DataConnectionUtilities.shouldFetchAttachments())
                 .placeholder {
                     Image("observations")

--- a/Mage/UI/Location/LocationSummaryView.swift
+++ b/Mage/UI/Location/LocationSummaryView.swift
@@ -34,7 +34,7 @@ struct LocationSummaryView: View {
                         .requestModifier(ImageCacheProvider.shared.accessTokenModifier)
                         .forceRefresh()
                         .cacheOriginalImage()
-                        .onlyFromCache(DataConnectionUtilities.shouldFetchAttachments())
+                        .onlyFromCache(!DataConnectionUtilities.shouldFetchAttachments())
                         .placeholder {
                             Image(systemName: "person.crop.square")
                                 .symbolRenderingMode(.monochrome)


### PR DESCRIPTION
# 1556 - Observation thumbnails not loading
- Fixed the glitch, made it so you ".onlyFromCache()" when appropriate network selected
- reversed parameter with bang (!): `.onlyFromCache(!DataConnectionUtilities.shouldFetchAttachments())`

## How it works
- previously, without the bang, it only downloaded from cache, unless you clicked into the image(s)
- the Network Settings for downloading Attachments are: .all, .wifi, .none
- when applying the bang, these settings act in the following:
  + *.all*: when opening the Observations ***TAB***, any image that is showing in the list will download immediately
  + *.wifi*: when opening the Observations Tab, no images will be downloaded immediately. But once you click into an image it will download automatically.
  + *.none*: no images are downloaded automatically. Once you open the Observations Tab -> select an image -> finally press the **View** button after being warned, it will finally download the image.

<img width="180" alt="Settings/NetworkSync" src="https://github.com/user-attachments/assets/291447ce-9749-4e03-8054-acefd564b8ad" />
<img width="180" alt="Settings/NetworkSync/Attachments" src="https://github.com/user-attachments/assets/f76fe071-494b-4ca2-a25f-3cc46795673f" />
<img width="180" alt="Settings/NetworkSync/Attachments/Options" src="https://github.com/user-attachments/assets/0b38efde-6d1a-469f-a49a-d09ef51819a2" />
<img width="180" alt="image/view" src="https://github.com/user-attachments/assets/b71b5928-851b-4d04-996b-0eb38221fdfb" />
