### PR TITLE
1370 - Observations temporarily duplicated in the UI

### DIFF
--- a/Mage/CoreData/User.swift
+++ b/Mage/CoreData/User.swift
@@ -63,7 +63,6 @@ import Kingfisher
     
     @objc public static func fetchCurrentUser(context: NSManagedObjectContext) -> User? {
         return context.performAndWait {
-            MageLogger.misc.debug("XXX current user \(String(describing: UserDefaults.standard.currentUserId))")
             return context.fetchFirst(User.self, key: UserKey.remoteId.key, value: UserDefaults.standard.currentUserId ?? "")
         }
     }
@@ -75,13 +74,8 @@ import Kingfisher
         
         let url = "\(baseURL.absoluteURL)/api/users/myself";
         let manager = MageSessionManager.shared();
-        let methodStart = Date()
-        MageLogger.misc.debug("TIMING Fetching Myself @ \(methodStart)")
         let task = manager?.get_TASK(url, parameters: nil, progress: nil, success: { task, responseObject in
-            MageLogger.misc.debug("TIMING Fetched Myself. Elapsed: \(methodStart.timeIntervalSinceNow) seconds")
             
-            let saveStart = Date()
-            MageLogger.misc.debug("TIMING Saving Myself @ \(saveStart)")
             @Injected(\.persistence)
             var persistence: Persistence
             
@@ -119,16 +113,11 @@ import Kingfisher
         }
         let url = "\(baseURL.absoluteURL)/api/users/\(userId)";
         let manager = MageSessionManager.shared();
-        let methodStart = Date()
-        MageLogger.misc.debug("TIMING Fetching User /api/users/\(userId) @ \(methodStart)")
         let task = manager?.get_TASK(url, parameters: nil, progress: nil, success: { task, responseObject in
-            MageLogger.misc.debug("TIMING Fetched User /api/users/\(userId) . Elapsed: \(methodStart.timeIntervalSinceNow) seconds")
             
             let saveStart = Date()
-            MageLogger.misc.debug("TIMING Saving User /api/users/\(userId)  @ \(saveStart)")
             if let responseData = responseObject as? Data {
                 if responseData.count == 0 {
-                    MageLogger.misc.debug("Users are empty");
                     success?(task, nil);
                     return;
                 }
@@ -153,7 +142,7 @@ import Kingfisher
                     }
                 }
             } completion: { contextDidSave, error in
-                MageLogger.misc.debug("TIMING Saved User /api/users/\(userId). Elapsed: \(saveStart.timeIntervalSinceNow) seconds")
+                MageLogger.misc.debug("TIMING Saved User /api/users/\(userId, privacy: .private). Elapsed: \(saveStart.timeIntervalSinceNow) seconds")
 
                 if let error = error {
                     if let failure = failure {
@@ -179,15 +168,12 @@ import Kingfisher
         let url = "\(baseURL.absoluteURL)/api/users";
         let manager = MageSessionManager.shared();
         let methodStart = Date()
-        MageLogger.misc.debug("TIMING Fetching Users @ \(methodStart)")
         let task = manager?.get_TASK(url, parameters: nil, progress: nil, success: { task, responseObject in
             MageLogger.misc.debug("TIMING Fetched Users. Elapsed: \(methodStart.timeIntervalSinceNow) seconds")
             
             let saveStart = Date()
-            MageLogger.misc.debug("TIMING Saving Users @ \(saveStart)")
             if let responseData = responseObject as? Data {
                 if responseData.count == 0 {
-                    MageLogger.misc.debug("Users are empty");
                     success?(task, nil);
                     return;
                 }

--- a/Mage/Extensions/ArrayExtensions.swift
+++ b/Mage/Extensions/ArrayExtensions.swift
@@ -15,3 +15,10 @@ extension Array {
         }
     }
 }
+
+extension Array where Element: Identifiable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element.ID>()
+        return self.filter { seen.insert($0.id).inserted }
+    }
+}

--- a/Mage/Mixins/DataSourceMap.swift
+++ b/Mage/Mixins/DataSourceMap.swift
@@ -180,7 +180,7 @@ class DataSourceMap: MapMixin {
         var removals: [DataSourceAnnotation] = []
         for change in differences {
             switch change {
-            case .insert(let offset, let element, _):
+            case .insert(_, let element, _):
                 let existing = mapView.annotations.first(where: { mapAnnotation in
                     guard let mapAnnotation = mapAnnotation as? DataSourceAnnotation else {
                         return false
@@ -192,8 +192,7 @@ class DataSourceMap: MapMixin {
                 } else {
                     inserts.append(element)
                 }
-                MageLogger.misc.debug("insert offset \(offset) for element \(element)")
-            case .remove(let offset, let element, _):
+            case .remove(_, let element, _):
                 let existing = mapView.annotations.compactMap({ mapAnnotation in
                     mapAnnotation as? DataSourceAnnotation
                 }).filter({ mapAnnotation in
@@ -204,14 +203,11 @@ class DataSourceMap: MapMixin {
                     return false
                 })
                 removals.append(contentsOf: existing)
-                MageLogger.misc.debug("remove offset \(offset) for element \(element)")
             }
         }
-        MageLogger.misc.debug("Inserting \(inserts.count), removing: \(removals.count)")
         
         mapView.addAnnotations(inserts)
         mapView.removeAnnotations(removals)
-        MageLogger.misc.debug("Annotation count: \(mapView.annotations.count)")
         
         return !inserts.isEmpty || !removals.isEmpty
     }
@@ -239,7 +235,7 @@ class DataSourceMap: MapMixin {
         var removals: [MKOverlay] = []
         for change in differences {
             switch change {
-            case .insert(let offset, let element, _):
+            case .insert(_, let element, _):
                 let existing = mapView.overlays.first(where: { mapOverlay in
                     guard let mapOverlay = mapOverlay as? DataSourceIdentifiable else {
                         return false
@@ -249,8 +245,7 @@ class DataSourceMap: MapMixin {
                 if existing == nil, let element = element as? MKOverlay {
                     inserts.append(element)
                 }
-                MageLogger.misc.debug("insert offset: \(String(describing: offset)) for element: \(String(describing: element))")
-            case .remove(let offset, let element, _):
+            case .remove(_, let element, _):
                 let existing = mapView.overlays.compactMap({ mapOverlay in
                     mapOverlay as? DataSourceIdentifiable
                 }).filter({ mapOverlay in
@@ -263,14 +258,11 @@ class DataSourceMap: MapMixin {
                     identifiable as? MKOverlay
                 }
                 removals.append(contentsOf: existing)
-                MageLogger.misc.debug("remove offset: \(String(describing: offset)) for element: \(String(describing: element))")
             }
         }
-        MageLogger.misc.debug("Inserting \(inserts.count), removing: \(removals.count)")
         
         mapView.addOverlays(inserts)
         mapView.removeOverlays(removals)
-        MageLogger.misc.debug("Annotation count: \(mapView.overlays.count)")
         return !inserts.isEmpty || !removals.isEmpty
     }
     

--- a/Mage/UI/Observation/ObservationList.swift
+++ b/Mage/UI/Observation/ObservationList.swift
@@ -39,7 +39,7 @@ struct ObservationList: View {
         .background(Color.backgroundColor)
         .foregroundColor(Color.onSurfaceColor)
         .onAppear {
-            viewModel.fetchObservations()
+            viewModel.reload()
         }
     }
 

--- a/Mage/UI/User/UserViewSwiftUI.swift
+++ b/Mage/UI/User/UserViewSwiftUI.swift
@@ -139,7 +139,7 @@ struct UserViewSwiftUI: View {
         .listSectionSeparator(.hidden)
         .background(Color.backgroundColor)
         .onAppear {
-            viewModel.fetchObservations()
+            viewModel.reload()
             mixins.addMixin(OnlineLayerMapMixin())
             mixins.addMixin(ObservationMap(mapFeatureRepository: ObservationMapFeatureRepository(userUri: viewModel.uri)))
         }

--- a/Mage/ViewModel/Observation/ObservationsViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationsViewModel.swift
@@ -112,7 +112,7 @@ class ObservationsViewModel: ObservableObject {
                 paginatedBy: trigger.signal(activatedBy: TriggerId.loadMore)
             )
             .scan([URIItem]()) { existing, new in
-                return (existing + new)
+                (existing + new).uniqued() // FIX: loadMore appears to duplicate fresh observations until they sync
             }
             .map { uriItems in
                 // Convert [URIItem] to [ObservationItem]

--- a/Mage/ViewModel/Observation/ObservationsViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationsViewModel.swift
@@ -109,7 +109,9 @@ class ObservationsViewModel: ObservableObject {
             repository.observations(
                 paginatedBy: trigger.signal(activatedBy: TriggerId.loadMore)
             )
-            .scan([]) { $0 + $1 }
+            .scan([]) { existing, new in
+                (existing + new).uniqued() // NOTE: this is a band-aid to fix duplicates issue #1370
+            }
             .map { uriItems in
                 // Convert [URIItem] to [ObservationItem]
                 uriItems.compactMap { uriItem in

--- a/Mage/ViewModel/User/UserViewViewModel.swift
+++ b/Mage/ViewModel/User/UserViewViewModel.swift
@@ -66,9 +66,11 @@ class UserViewViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .assign(to: &$user)
+        
+        createFetchObservationsPublisher()
     }
     
-    func fetchObservations(limit: Int = 100) {
+    func createFetchObservationsPublisher(limit: Int = 100) {
         Publishers.PublishAndRepeat(
             onOutputFrom: trigger.signal(activatedBy: TriggerId.reload)
         ) { [trigger, observationRepository, uri] in
@@ -77,7 +79,7 @@ class UserViewViewModel: ObservableObject {
                 paginatedBy: trigger.signal(activatedBy: TriggerId.loadMore)
             )
             .scan([]) { existing, new in
-                (existing + new).uniqued() // NOTE: this is a band-aid to fix duplicates issue #1370
+                (existing + new)
             }
             .map { State.loaded(rows: $0) }
             .catch { error in

--- a/Mage/ViewModel/User/UserViewViewModel.swift
+++ b/Mage/ViewModel/User/UserViewViewModel.swift
@@ -79,7 +79,7 @@ class UserViewViewModel: ObservableObject {
                 paginatedBy: trigger.signal(activatedBy: TriggerId.loadMore)
             )
             .scan([]) { existing, new in
-                (existing + new)
+                (existing + new).uniqued() // FIX: loadMore appears to duplicate fresh observations until they sync
             }
             .map { State.loaded(rows: $0) }
             .catch { error in

--- a/Mage/ViewModel/User/UserViewViewModel.swift
+++ b/Mage/ViewModel/User/UserViewViewModel.swift
@@ -76,7 +76,9 @@ class UserViewViewModel: ObservableObject {
                 userUri: uri,
                 paginatedBy: trigger.signal(activatedBy: TriggerId.loadMore)
             )
-            .scan([]) { $0 + $1 }
+            .scan([]) { existing, new in
+                (existing + new).uniqued() // NOTE: this is a band-aid to fix duplicates issue #1370
+            }
             .map { State.loaded(rows: $0) }
             .catch { error in
                 return Just(State.failure(error: error))

--- a/Packages/MapFramework/Sources/MapFramework/MapCoordinator.swift
+++ b/Packages/MapFramework/Sources/MapFramework/MapCoordinator.swift
@@ -90,7 +90,6 @@ public class MapCoordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDel
             guard let annotation = view.annotation as? DataSourceAnnotation else {
                 continue
             }
-            NSLog("check if should enlarge \(annotation.shouldEnlarge)")
             if annotation.shouldEnlarge {
                 UIView.animate(withDuration: 0.5, delay: 0.0, options: .curveEaseInOut) {
                     annotation.enlargeAnnoation()


### PR DESCRIPTION
# Observations temporarily duplicated
> Gitlab: https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1370

## *hack* Solution
- remove duplicates from the array entirely

## Problem area(s)
- Observations Tab List
- User Observation List

## How to test
- start in either list
- create new observation, add a form that allows you to add a photo, add a photo, save
- **Quickly** before it finishes uploading or there is a refresh of observations from the server
  + go to either list
  + scroll to the bottom of the list, note the last observation
  + click on *any* observation, then immediately go back to the list by hitting *back*
  + scroll to the bottom, note the last observation is not a duplicate

- if you want to see the error, just watch video in gitlab story

## Note
- this is a temporary fix because after a **lot** of investigation I still cannot figure out why the duplicates are happening