### PR TITLE
1474 - Apple Maps bug

### DIFF
--- a/Mage/Mixins/MapDirectionsMixin.swift
+++ b/Mage/Mixins/MapDirectionsMixin.swift
@@ -230,7 +230,8 @@ class MapDirectionsMixin: NSObject, MapMixin {
             NotificationCenter.default.post(name: .MapRequestFocus, object: nil)
         }));
         
-        let appleMapsQueryString = "daddr=\(location.coordinate.latitude),\(location.coordinate.longitude)&ll=\(location.coordinate.latitude),\(location.coordinate.longitude)&q=\(title ?? "")".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed);
+        let appleMapsQueryString = "daddr=\(location.coordinate.latitude),\(location.coordinate.longitude)&dirflg=d".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed);
+        
         let appleMapsUrl = URL(string: "https://maps.apple.com/?\(appleMapsQueryString ?? "")");
         
         let googleMapsUrl = URL(string: "https://maps.google.com/?\(appleMapsQueryString ?? "")");

--- a/Mage/ObservationActionHandler.swift
+++ b/Mage/ObservationActionHandler.swift
@@ -11,7 +11,7 @@ import Foundation
 class ObservationActionHandler {
     
     static func getDirections(latitude: CLLocationDegrees, longitude: CLLocationDegrees, title: String, viewController: UIViewController, extraActions: [UIAlertAction]? = nil, sourceView: UIView? = nil) {
-        let appleMapsQueryString = "daddr=\(latitude),\(longitude)&ll=\(latitude),\(longitude)&q=\(title)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed);
+        let appleMapsQueryString = "daddr=\(latitude),\(longitude)&dirflg=d".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed);
         let appleMapsUrl = URL(string: "https://maps.apple.com/?\(appleMapsQueryString ?? "")");
         
         let googleMapsUrl = URL(string: "https://maps.google.com/?\(appleMapsQueryString ?? "")");


### PR DESCRIPTION
1474 - Navigation to Observation on iOS via Apple Maps Fails
> gitlab: https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1474

- When using the "navigate to" feature for any observation and *Apple Maps*, when opening Apple Maps the pin would be missing and nothing would happen. However you would be at the correct location on the map.
- This fix updated parameters to match Apple's latest changes

https://github.com/user-attachments/assets/1a302b42-3964-4293-a8b6-dfc5f3621599

