### PR TITLE
Added fix for Attachments force unwrap in error handling logic

### DIFF
--- a/sdk/AttachmentPushService.swift
+++ b/sdk/AttachmentPushService.swift
@@ -349,9 +349,6 @@ extension InjectedValues {
             return
         }
         
-        let data = response.data
-        let json = try? JSONSerialization.jsonObject(with: data!, options: []) as? [String: Any]
-        
         if let error {
             MageLogger.misc.error("ATTACHMENT - upload complete with error \(error)")
             // try again
@@ -360,16 +357,20 @@ extension InjectedValues {
         }
         
         if let httpResponse = task?.response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            MageLogger.misc.error("ATTACHMENT - response code error: \(httpResponse.statusCode)")
             // try again
             removeTask(taskIdentifier: task?.taskIdentifier)
             return
         }
         
-        if data == nil {
+        guard let data = response.data else {
+            MageLogger.misc.error("ATTACHMENT - response data is nil")
             // try again
             removeTask(taskIdentifier: task?.taskIdentifier)
             return
         }
+        
+        let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
         
         guard let context else {
             return


### PR DESCRIPTION
Fixes a random crash that can happen when an error occurs when syncing attachments.

We were force unwrapping data before we checked for errors and HTTP status code. The crash should now be prevented because we safely unwrap it with a `guard` statement.

[MAGE-1600](https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1600)

<img width="1716" height="1150" alt="Screenshot 2025-09-10 at 11 59 35 AM" src="https://github.com/user-attachments/assets/e4bc2f23-dddc-433f-9666-1d62799eeb64" />


