### PR TITLE
1601 - Crash on createTileArrays() - Not Thread Safe

### DIFF
--- a/Mage/DataSourceMapViewModel.swift
+++ b/Mage/DataSourceMapViewModel.swift
@@ -41,7 +41,7 @@ class DataSourceMapViewModel {
     
     @Published var annotations: [DataSourceAnnotation] = []
     @Published var featureOverlays: [MKOverlay] = []
-    @Published var tileOverlays: [DataSourceTileOverlay] = []
+    @Published var tileOverlay: DataSourceTileOverlay?
     
     let requerySubject = PassthroughSubject<Void, Never>()
     
@@ -112,17 +112,13 @@ class DataSourceMapViewModel {
         featureOverlays = features?.overlays ?? []
     }
     
-    @discardableResult
-    private func createTileOverlays() -> [MKTileOverlay] {
-        guard let repository = repository else {
-            return []
-        }
+    private func createTileOverlays() {
+        guard let repository = repository else { return }
         let newOverlay = DataSourceTileOverlay(tileRepository: repository, key: key)
         newOverlay.minimumZ = minZoom
         newOverlay.maximumZ = maximumTileZoom
         
-        tileOverlays = [newOverlay]
-        return tileOverlays
+        tileOverlay = newOverlay
     }
     
     func itemKeys(

--- a/Mage/Mixins/DataSourceMap.swift
+++ b/Mage/Mixins/DataSourceMap.swift
@@ -71,7 +71,7 @@ class DataSourceMap: MapMixin {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] tileOverlay in
                 Task { [weak self] in
-                    await self?.updateTileOverlays(tileOverlay: tileOverlay)
+                    await self?.updateTileOverlay(tileOverlay: tileOverlay)
                 }
             }
             .store(in: &cancellable)
@@ -86,7 +86,7 @@ class DataSourceMap: MapMixin {
     }
     
     @MainActor
-    private func updateTileOverlays(tileOverlay: DataSourceTileOverlay?) {
+    private func updateTileOverlay(tileOverlay: DataSourceTileOverlay?) {
         guard let mapView = mapView, let viewModel = viewModel else {
             return
         }

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -30,9 +30,6 @@ class ObservationsMap: DataSourceMap {
     init() {
         super.init(
             dataSource: DataSources.observation
-//            ,
-//            repository: repository,
-//            mapFeatureRepository: mapFeatureRepository
         )
         viewModel = DataSourceMapViewModel(
             dataSource: dataSource,
@@ -44,55 +41,60 @@ class ObservationsMap: DataSourceMap {
 
         UserDefaults.standard.publisher(for: \.observationTimeFilterKey)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.observationTimeFilterUnitKey)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.observationTimeFilterNumberKey)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.importantFilterKey)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.favoritesFilterKey)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
@@ -106,7 +108,9 @@ class ObservationsMap: DataSourceMap {
                             self?.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
                             await self?.repository.clearCache()
                             await self?.redrawFeatures()
-                            self?.viewModel?.refresh()
+                            await MainActor.run {
+                                self?.viewModel?.refresh()
+                            }
                         }
                     }
                 }

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -48,7 +48,9 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
@@ -58,7 +60,9 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
@@ -68,7 +72,9 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
@@ -78,7 +84,9 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
@@ -87,7 +95,9 @@ class ObservationsMap: DataSourceMap {
             .sink { [weak self] order in
                 Task { [self] in
                     await self?.repository.clearCache()
-                    self?.viewModel?.refresh()
+                    await MainActor.run {
+                        self?.viewModel?.refresh()
+                    }
                 }
             }
             .store(in: &cancellable)
@@ -101,7 +111,9 @@ class ObservationsMap: DataSourceMap {
                             self?.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
                             await self?.repository.clearCache()
                             await self?.redrawFeatures()
-                            self?.viewModel?.refresh()
+                            await MainActor.run {
+                                self?.viewModel?.refresh()
+                            }
                         }
                     }
                 }

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -44,13 +44,12 @@ class ObservationsMap: DataSourceMap {
 
         UserDefaults.standard.publisher(for: \.observationTimeFilterKey)
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    await MainActor.run {
-                        self?.viewModel?.refresh()
-                    }
+                    self?.viewModel?.refresh()
                 }
             }
             .store(in: &cancellable)
@@ -60,9 +59,7 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    await MainActor.run {
-                        self?.viewModel?.refresh()
-                    }
+                    self?.viewModel?.refresh()
                 }
             }
             .store(in: &cancellable)
@@ -72,9 +69,7 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    await MainActor.run {
-                        self?.viewModel?.refresh()
-                    }
+                    self?.viewModel?.refresh()
                 }
             }
             .store(in: &cancellable)
@@ -84,20 +79,17 @@ class ObservationsMap: DataSourceMap {
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
                     await self?.repository.clearCache()
-                    await MainActor.run {
-                        self?.viewModel?.refresh()
-                    }
+                    self?.viewModel?.refresh()
                 }
             }
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.favoritesFilterKey)
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 Task { [self] in
                     await self?.repository.clearCache()
-                    await MainActor.run {
-                        self?.viewModel?.refresh()
-                    }
+                    self?.viewModel?.refresh()
                 }
             }
             .store(in: &cancellable)
@@ -111,9 +103,7 @@ class ObservationsMap: DataSourceMap {
                             self?.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
                             await self?.repository.clearCache()
                             await self?.redrawFeatures()
-                            await MainActor.run {
-                                self?.viewModel?.refresh()
-                            }
+                            self?.viewModel?.refresh()
                         }
                     }
                 }

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -55,6 +55,7 @@ class ObservationsMap: DataSourceMap {
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.observationTimeFilterUnitKey)
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
@@ -65,6 +66,7 @@ class ObservationsMap: DataSourceMap {
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.observationTimeFilterNumberKey)
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in
@@ -75,6 +77,7 @@ class ObservationsMap: DataSourceMap {
             .store(in: &cancellable)
         UserDefaults.standard.publisher(for: \.importantFilterKey)
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
                 Task { [self] in

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -43,10 +43,11 @@ class ObservationsMap: DataSourceMap {
             .removeDuplicates()
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
+                guard let self = self else { return }
                 Task { [self] in
-                    await self?.repository.clearCache()
+                    await self.repository.clearCache()
                     await MainActor.run {
-                        self?.viewModel?.refresh()
+                        self.viewModel?.refresh()
                     }
                 }
             }
@@ -55,10 +56,11 @@ class ObservationsMap: DataSourceMap {
             .removeDuplicates()
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
+                guard let self = self else { return }
                 Task { [self] in
-                    await self?.repository.clearCache()
+                    await self.repository.clearCache()
                     await MainActor.run {
-                        self?.viewModel?.refresh()
+                        self.viewModel?.refresh()
                     }
                 }
             }
@@ -67,10 +69,11 @@ class ObservationsMap: DataSourceMap {
             .removeDuplicates()
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
+                guard let self = self else { return }
                 Task { [self] in
-                    await self?.repository.clearCache()
+                    await self.repository.clearCache()
                     await MainActor.run {
-                        self?.viewModel?.refresh()
+                        self.viewModel?.refresh()
                     }
                 }
             }
@@ -79,10 +82,11 @@ class ObservationsMap: DataSourceMap {
             .removeDuplicates()
             .sink { [weak self] order in
                 NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
+                guard let self = self else { return }
                 Task { [self] in
-                    await self?.repository.clearCache()
+                    await self.repository.clearCache()
                     await MainActor.run {
-                        self?.viewModel?.refresh()
+                        self.viewModel?.refresh()
                     }
                 }
             }
@@ -90,10 +94,11 @@ class ObservationsMap: DataSourceMap {
         UserDefaults.standard.publisher(for: \.favoritesFilterKey)
             .removeDuplicates()
             .sink { [weak self] order in
+                guard let self = self else { return }
                 Task { [self] in
-                    await self?.repository.clearCache()
+                    await self.repository.clearCache()
                     await MainActor.run {
-                        self?.viewModel?.refresh()
+                        self.viewModel?.refresh()
                     }
                 }
             }
@@ -104,12 +109,13 @@ class ObservationsMap: DataSourceMap {
             .sink { [weak self] notification in
                 if let event: EventModel = notification.object as? EventModel {
                     if let eventId = event.remoteId, eventId == Server.currentEventId() {
+                        guard let self = self else { return }
                         Task { [self] in
-                            self?.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
-                            await self?.repository.clearCache()
-                            await self?.redrawFeatures()
+                            self.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
+                            await self.repository.clearCache()
+                            await self.redrawFeatures()
                             await MainActor.run {
-                                self?.viewModel?.refresh()
+                                self.viewModel?.refresh()
                             }
                         }
                     }


### PR DESCRIPTION
- For some reason the tileOverlays was set as an array. It's never used as an array. The parent never sees more than one in the array. I made it a single object. Seems to have solved the problem.
- Second, I've wrapped problematic calls to *refresh()* function to stay on main thread now.