### PR TITLE
1641 - Contact Us Fails Silently without an Email Client

### DIFF
--- a/Mage/SettingsTableViewController.m
+++ b/Mage/SettingsTableViewController.m
@@ -250,7 +250,33 @@
     if ([[UIApplication sharedApplication] canOpenURL:mailtoURL]) {
         [[UIApplication sharedApplication] openURL:mailtoURL options:@{} completionHandler:nil];
     } else {
-        NSLog(@"Cannot open mail client for: %@", mailtoURL);
+        NSLog(@"Cannot open mail client for: %@, It looks like you don't have a mail app configured on this device.", mailtoURL);
+
+        NSString *supportEmail = @"xyz@example.com"; // TODO: extract this from server or add permenantly in UserDefaults?
+
+        // This is the popup
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Could not open mail"
+                                                                       message:[NSString stringWithFormat:@"Please contact support at: %@", supportEmail]
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+
+        // This is the "Copy Address" action that copies our *supportEmail* to the iPhone's clipboard
+        UIAlertAction *copyAction = [UIAlertAction actionWithTitle:@"Copy Address"
+                                                             style:UIAlertActionStyleDefault
+                                                           handler:^(UIAlertAction * _Nonnull action) {
+            UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+            pasteboard.string = supportEmail;
+        }];
+
+        // Both buttons close the popup, but this one is just a backup for if the user doesn't want to copy the address
+        UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:nil];
+
+        [alert addAction:copyAction];
+        [alert addAction:okAction];
+
+        UINavigationController *navigationController = self.navigationController;
+        [navigationController presentViewController:alert animated:YES completion:nil];
     }
 }
 

--- a/Mage/SettingsTableViewController.m
+++ b/Mage/SettingsTableViewController.m
@@ -252,11 +252,9 @@
     } else {
         NSLog(@"Cannot open mail client for: %@, It looks like you don't have a mail app configured on this device.", mailtoURL);
 
-        NSString *supportEmail = @"xyz@example.com"; // TODO: extract this from server or add permenantly in UserDefaults?
-
         // This is the popup
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Could not open mail"
-                                                                       message:[NSString stringWithFormat:@"Please contact support at: %@", supportEmail]
+                                                                       message:[NSString stringWithFormat:@"Please contact support at: %@", recipient]
                                                                 preferredStyle:UIAlertControllerStyleAlert];
 
         // This is the "Copy Address" action that copies our *supportEmail* to the iPhone's clipboard
@@ -264,7 +262,7 @@
                                                              style:UIAlertActionStyleDefault
                                                            handler:^(UIAlertAction * _Nonnull action) {
             UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-            pasteboard.string = supportEmail;
+            pasteboard.string = recipient;
         }];
 
         // Both buttons close the popup, but this one is just a backup for if the user doesn't want to copy the address


### PR DESCRIPTION
# Contact Us Fails Silently without an Email Client
- fail state now shows popup

<img width="250" alt="Contact Us Fail Popup" src="https://github.com/user-attachments/assets/b8a8ead4-729f-48ce-9069-18d8dea8404e" />

