### PR TITLE
[Auth][PR1] Authentication module skeleton (no behavior change)

### DIFF
--- a/Authentication/Docs/AuthObsolescence.md
+++ b/Authentication/Docs/AuthObsolescence.md
@@ -1,0 +1,9 @@
+# Auth Obsolescence Ledger
+
+> Any removal must be listed here with justification and a replacement path.
+
+| Item | Why it’s obsolete | Replacement | User impact | Removal PR |
+|---|---|---|---|---|
+| `AuthenticationButton` (+ delegate) | Strategy selection is owned by modern `IDPCoordinator`/SwiftUI; duplicate abstraction | `IDPCoordinator` APIs and SwiftUI entry points | None; UI routes are equivalent | PR9 |
+| Obj-C XIB login/signup screens | Replaced by SwiftUI screens with equivalent validation, CAPTCHA, and error flows | `LoginViewSwiftUI`, `SignupViewSwiftUI` | None; parity proven before removal | PR9 |
+| AFNetworking (auth paths) | Superseded by URLSession client with same endpoints and error mapping | `AuthHTTPClient` | None; contract parity tests pass | PR10 |

--- a/Authentication/Docs/AuthParity.md
+++ b/Authentication/Docs/AuthParity.md
@@ -1,0 +1,76 @@
+# Auth Parity Matrix (Legacy Obj-C/AFN → New Swift/URLSession/SwiftUI)
+
+> Source of truth for auth migration. No PR may regress any “✅ parity” item.
+
+## Legend
+- Legacy: behavior in Obj-C/AFNetworking code today
+- New: behavior target in Swift/URLSession/SwiftUI code
+- Status: ❓(pending), 🧪(tests landed), ✅(parity proven), ⚠️(needs decision)
+- Gate: feature flag or build config used to control rollout
+
+---
+
+### Core Flows
+
+| Area | Legacy (Obj-C/AFN) | New (Swift) | Status | Gate | Notes |
+|---|---|---|---:|:---:|---|
+| **Local Login** | Username+password → token persisted (`MageSessionManager.setToken`, `StoredPassword`). Errors map to alerts. | Same contract; token persisted via new `CredentialStore`. Same error mapping or equivalent wording. | ❓ | — | Preserve strings semantically (exact match not required). iOS 16+. |
+| **IDP (initial)** | Coordinator + web view returns token; uses legacy coordinator. | New `IDPCoordinator` with same entry/exit semantics (OIDC first). | ❓ | `authNextGenEnabled` | Scope = OIDC first; confirm SAML later. |
+| **Signup + CAPTCHA** | Captcha always visible; refresh on username change; policy feedback; server 401/409 handling. | Same behavior; always show CAPTCHA; same 401/409 handling; password policy checks. | ❓ | `authNextGenEnabled` | Keep “always visible CAPTCHA” invariant. |
+
+---
+
+### Session / Token Handling
+
+| Area | Legacy | New | Status | Gate | Notes |
+|---|---|---|---:|:---:|---|
+| **Token use** | `MageSessionManager` & `MageSession` add bearer, validate responses. | URLSession client adds bearer; same validation outcomes. | ❓ | — | Same exempt paths: signin/authorize/devices/password/auth/token. |
+| **Token expiry reaction** | No silent refresh. If online login and 401: `expireToken` + post `MAGETokenExpiredNotification`. If offline login and 401: post `MAGEServerContactedAfterOfflineLogin`. | Same notifications fired, same branching. | ❓ | — | Derived from `MageSessionManager.m` and `MageSession.swift`. |
+| **Offline login** | Allowed if password cached; token reused offline until server is contacted. | Same; no forced ping at launch; honors offline mode semantics. | ❓ | — | Confirm exact cached-password signal we will key off. |
+| **Logout** | Clears keychain + in-mem token; forces login. | Same. | ❓ | — | — |
+
+---
+
+### Change Password
+
+| Area | Legacy | New | Status | Gate | Notes |
+|---|---|---|---:|:---:|---|
+| **Change Password Screen** | Validates required fields, mismatch, current=new; strength meter via `DBZxcvbn`. Calls `PUT /api/users/myself/password`. On success: modal → logout. | Same validation & endpoint semantics; migrate UI to SwiftUI later; parity first. | ❓ | `authNextGenEnabled` (when migrated) | Until migration, legacy VC remains. |
+
+---
+
+### Server & Environment
+
+| Area | Legacy | New | Status | Gate | Notes |
+|---|---|---|---:|:---:|---|
+| **Server picker** | User can switch servers at login. Nothing purged until a new valid server is set or switch is canceled. | Same; “commit on success” semantics; otherwise keep prior state. | ❓ | — | Maintain exact semantics. |
+| **Minimum Server** | ≥ 6.0 required for new flows. | Target endpoints assume v6+. | 🧪 | — | Documented constraint. |
+| **Minimum iOS** | iOS 16 | iOS 16 | ✅ | — | No shims needed. |
+
+---
+
+### Legal & Analytics
+
+| Area | Legacy | New | Status | Gate | Notes |
+|---|---|---|---:|:---:|---|
+| **EULA** | Must be agreed before or immediately after first login. | Same gate remains; no bypass. | ❓ | — | Confirm exact screen/timing. |
+| **Analytics** | Username and authorizationToken tracked (where applicable). | Same events (names/params) preserved. | ⚠️ | — | Need exact event names & locations. |
+
+---
+
+## Notifications to Preserve
+
+- `MAGETokenExpiredNotification` — fired when a valid online session gets a 401 and we expire the token.
+- `MAGEServerContactedAfterOfflineLogin` — fired when offline-mode user hits server and receives 401.
+
+We must prove, via tests, these still fire under the same conditions.
+
+---
+
+## Test Plan Index (to be added as PRs land)
+
+- Unit: `CredentialStore`, error mapping, password policy.
+- Integration (stubbed): AFN vs URLSession contract tests for `/login`, `/users/signups`, `/verifications`, `/users/myself/password`.
+- UI: ViewInspector for SwiftUI login/signup (fields, disabled states, error text).
+- Notification tests: token-expiry → notifications above.
+

--- a/Authentication/Impl/AuthServiceFactory.swift
+++ b/Authentication/Impl/AuthServiceFactory.swift
@@ -1,0 +1,13 @@
+//
+//  AuthServiceFactory.swift
+//  Authentication
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Foundation
+
+enum AuthServiceFactory {
+    static func make() -> AuthService { NoopAuthService() }
+}

--- a/Authentication/Impl/NoopAuthService.swift
+++ b/Authentication/Impl/NoopAuthService.swift
@@ -1,0 +1,28 @@
+//
+//  NoopAuthService.swift
+//  Authentication
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Foundation
+
+final class NoopAuthService: AuthService {
+    init() {}
+    func loginLocal(_ c: AuthCredantials) async throws -> AuthSession {
+        throw AuthError.unimplemented("loginLocal")
+    }
+    func logout() async {}
+    func beginIDP(_ provider: IDPProvider) async throws { throw AuthError.unimplemented("beginIDP") }
+    func completeIDP() async throws -> AuthSession { throw AuthError.unimplemented("completeIDP") }
+    func fetchCaptcha(for username: String?) async throws -> Captcha {
+        throw AuthError.unimplemented("fetchCaptcha")
+    }
+    func verifyCaptcha(token: String, value: String) async throws -> CaptchaVerification {
+        throw AuthError.unimplemented("verifyCaptcha")
+    }
+    func signup(_ request: SignupRequest) async throws -> SignupResult {
+        throw AuthError.unimplemented("signup")
+    }
+}

--- a/Authentication/Public/AuthErrors.swift
+++ b/Authentication/Public/AuthErrors.swift
@@ -1,0 +1,61 @@
+//
+//  AuthErrors.swift
+//  Authentication
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Foundation
+
+enum AuthError: Error, Equatable, LocalizedError {
+    case invalidCredentials
+    case accountDisabled
+    case network(underlying: Error?)
+    case server(status: Int, message: String?)
+    case decoding(underlying: Error?)
+    case policyViolation(message: String)
+    case cancelled
+    case unimplemented(String = "")
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidCredentials: return "Invalid username or password."
+        case .accountDisabled: return "This account is disabled."
+        case .network:            return "Network error. Check your connection."
+        case .server(_, let msg): return msg ?? "Server error."
+        case .decoding: return "Failed to parse server response."
+        case .policyViolation(let m): return m
+        case .cancelled: return "Request was cancelled."
+        case .unimplemented(let hint):
+            return hint.isEmpty ? "Not implemented." : "Not implemented: \(hint)."
+        }
+    }
+}
+
+// MARK: - Equatable (manual because Error? isn't Equatable)
+func == (lhs: AuthError, rhs: AuthError) -> Bool {
+    switch (lhs, rhs) {
+    case (.invalidCredentials, .invalidCredentials),
+        (.accountDisabled, .accountDisabled),
+        (.cancelled, .cancelled):
+        return true
+        
+        // We intentionally ignore the underlying Error payload for eauality
+    case (.network, .network),
+        (.decoding, .decoding):
+        return true
+        
+    case let (.server(s1, m1), .server(s2, m2)):
+        return s1 == s2 && m1 == m2
+        
+    case let (.policyViolation(m1), .policyViolation(m2)):
+        return m1 == m2
+        
+    case let (.unimplemented(h1), .unimplemented(h2)):
+        return h1 == h2
+        
+    default:
+        return false
+    }
+}

--- a/Authentication/Public/AuthModels.swift
+++ b/Authentication/Public/AuthModels.swift
@@ -1,0 +1,59 @@
+//
+//  AuthModels.swift
+//  Authentication
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Foundation
+
+enum IDPProvider: Equatable { case oidc, saml, custom(name: String) }
+enum AuthStrategy: Equatable { case local, idp(IDPProvider) }
+
+struct AuthCredantials: Equatable {
+    let username: String, password: String
+    init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+}
+
+struct AuthSession: Equatable {
+    let token: String, userId: String
+    init (token: String, userId: String) {
+        self.token = token
+        self.userId = userId
+    }
+}
+
+struct Captcha: Equatable {
+    let token: String
+    let imageData: Data?
+    init(token: String, imageData: Data?) {
+        self.token = token
+        self.imageData = imageData
+    }
+}
+
+struct CaptchaVerification: Equatable {
+    let isValid: Bool
+    init(isValid: Bool) { self.isValid = isValid }
+}
+
+
+struct SignupRequest: Equatable {
+    let displayName: String, username: String, password: String, email: String?
+    init(displayName: String, username: String, password: String, email: String?) {
+        self.displayName = displayName
+        self.username = username
+        self.password = password
+        self.email = email
+    }
+}
+
+struct SignupResult: Equatable {
+    let userId: String
+     init(userId: String) { self.userId = userId }
+}
+

--- a/Authentication/Public/AuthService.swift
+++ b/Authentication/Public/AuthService.swift
@@ -1,0 +1,21 @@
+//
+//  AuthService.swift
+//  Authentication
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Foundation
+
+protocol AuthService {
+    func loginLocal(_ credentials: AuthCredantials) async throws -> AuthSession
+    func logout() async
+    
+    func beginIDP(_ provider: IDPProvider) async throws
+    func completeIDP() async throws -> AuthSession
+    
+    func fetchCaptcha(for username: String?) async throws -> Captcha
+    func verifyCaptcha(token: String, value: String) async throws -> CaptchaVerification
+    func signup(_ request: SignupRequest) async throws -> SignupResult
+}

--- a/AuthenticationTests/AuthErrorTests.swift
+++ b/AuthenticationTests/AuthErrorTests.swift
@@ -1,0 +1,27 @@
+//
+//  AuthErrorTests.swift
+//  AuthenticationTests
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import XCTest
+@testable import MAGE
+
+final class AuthErrorTests: XCTestCase {
+    func testLocalizedDescriptionsAreNonEmpty() {
+        let cases: [AuthError] = [
+            .invalidCredentials, .accountDisabled, .network(underlying: nil),
+            .server(status: 500, message: nil), .decoding(underlying: nil),
+            .policyViolation(message: "Too short"), .cancelled, .unimplemented()
+            ]
+        
+        for err in cases { XCTAssertFalse((err.errorDescription ?? "").isEmpty) }
+    }
+    
+    func testEquatable() {
+        XCTAssertEqual(AuthError.invalidCredentials, .invalidCredentials)
+        XCTAssertNotEqual(AuthError.invalidCredentials, .accountDisabled)
+    }
+}

--- a/AuthenticationTests/NoopAuthServiceTests.swift
+++ b/AuthenticationTests/NoopAuthServiceTests.swift
@@ -1,0 +1,40 @@
+//
+//  NoopAuthServiceTests.swift
+//  AuthenticationTests
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import XCTest
+@testable import MAGE
+
+final class NoopAuthServiceTests: XCTestCase {
+    
+    func testNoopAlwaysUnimplemented() async {
+        let svc = NoopAuthService()
+        
+        await XCTAssertThrowsErrorAsync(try await svc.loginLocal(.init(username: "u", password: "p")))
+        await XCTAssertThrowsErrorAsync(try await svc.beginIDP(.oidc))
+        await XCTAssertThrowsErrorAsync(try await svc.completeIDP())
+        await XCTAssertThrowsErrorAsync(try await svc.fetchCaptcha(for: "u"))
+        await XCTAssertThrowsErrorAsync(try await svc.verifyCaptcha(token: "t", value: "v"))
+        await XCTAssertThrowsErrorAsync(try await svc.signup(.init(displayName: "d", username: "u", password: "p", email: nil)))
+    }
+}
+
+// Small async helper so we don't pull in extra deps
+private extension XCTestCase {
+    func XCTAssertThrowsErrorAsync<T>(
+        _ expression: @autoclosure () async throws -> T,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("Expected error", file: file, line: line)
+        } catch {
+            /* expected */
+        }
+    }
+}

--- a/MAGE.xcodeproj/project.pbxproj
+++ b/MAGE.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1958,7 +1958,36 @@
 		F7FED9DC275692850000915B /* apiSuccessNoAuthStrategies.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = apiSuccessNoAuthStrategies.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		847D5D8F2EA083CE005DF580 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Docs/AuthObsolescence.md,
+				Docs/AuthParity.md,
+				Impl/AuthServiceFactory.swift,
+				Impl/NoopAuthService.swift,
+				Public/AuthErrors.swift,
+				Public/AuthModels.swift,
+				Public/AuthService.swift,
+			);
+			target = F7ED5D2320052161007BD768 /* MAGETests */;
+		};
+		847D5D912EA08558005DF580 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Impl/AuthServiceFactory.swift,
+				Impl/NoopAuthService.swift,
+				Public/AuthErrors.swift,
+				Public/AuthModels.swift,
+				Public/AuthService.swift,
+			);
+			target = F7A94D6518AD9CB000CB9EE0 /* MAGE */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		847D5D822EA083BD005DF580 /* Authentication */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (847D5D912EA08558005DF580 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 847D5D8F2EA083CE005DF580 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Authentication; sourceTree = "<group>"; };
+		847D5D852EA083BD005DF580 /* AuthenticationTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = AuthenticationTests; sourceTree = "<group>"; };
 		A811F2832E3BEAF80016C5AB /* IntroViews */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = IntroViews; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
@@ -3540,6 +3569,8 @@
 		F7A94D5D18AD9CAF00CB9EE0 = {
 			isa = PBXGroup;
 			children = (
+				847D5D822EA083BD005DF580 /* Authentication */,
+				847D5D852EA083BD005DF580 /* AuthenticationTests */,
 				BD66678D2D82152100D9BBA0 /* MAGE.xctestplan */,
 				F7DE98912C1B355D005372F8 /* DebugUtilities */,
 				F776AC8E2BC9DADE000FAFB4 /* MapFramework */,
@@ -4433,6 +4464,10 @@
 			);
 			dependencies = (
 				F763326C2059CD4F00C5529C /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				847D5D822EA083BD005DF580 /* Authentication */,
+				847D5D852EA083BD005DF580 /* AuthenticationTests */,
 			);
 			name = MAGETests;
 			productName = MAGETests;

--- a/Mage/Localizable.xcstrings
+++ b/Mage/Localizable.xcstrings
@@ -276,6 +276,9 @@
         }
       }
     },
+    "Delete" : {
+      "comment" : "Alert delete button"
+    },
     "Downloaded %@ of %@" : {
       "localizations" : {
         "en" : {

--- a/MageTests/UserDefaultsFlagsTests.swift
+++ b/MageTests/UserDefaultsFlagsTests.swift
@@ -1,0 +1,24 @@
+//
+//  UserDefaultsFlagsTests.swift
+//  MAGETests
+//
+//  Created by Brent Michalski on 10/15/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import XCTest
+@testable import MAGE
+
+final class UserDefaultsFlagsTests: XCTestCase {
+    
+    func testAuthNextGenEnabled_DefaultsFalseAndFlips() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "authNextGenEnabled")
+        XCTAssertFalse(defaults.authNextGenEnabled)
+        defaults.authNextGenEnabled = true
+        XCTAssertTrue(defaults.authNextGenEnabled)
+        defaults.authNextGenEnabled = false
+        XCTAssertFalse(defaults.authNextGenEnabled)
+    }
+
+}


### PR DESCRIPTION
Summary
- Adds an Auth skeleton inside the MAGE app target:
  - Protocol + value types: AuthService, AuthModels, AuthErrors (manual Equatable)
  - NoopAuthService + factory for later swap-in
- Docs to enforce parity/refactor discipline:
  - Authentication/Docs/AuthParity.md
  - Authentication/Docs/AuthObsolescence.md
- Tests (MAGETests):
  - AuthErrorTests
  - NoopAuthServiceTests
  - (Optional) UserDefaultsFlagsTests

Behavior change
- None: app continues using legacy Obj-C/AFNetworking auth flows.
- No routing changes; no URLSession code introduced yet.

Validation
- Builds & launches with legacy login unchanged.
- Tests pass under MAGETests.
- Grep shows no `import Authentication` in app sources.

Rollback
- Single-commit revert restores prior state.
