### PR TITLE
Fixes Username and Password to use larger touch targets to improve tap experience

### DIFF
--- a/Mage/PasswordFieldView.swift
+++ b/Mage/PasswordFieldView.swift
@@ -11,31 +11,46 @@ import SwiftUI
 struct PasswordFieldView: View {
     @Binding var password: String
     @Binding var showPassword: Bool
-    
+    @FocusState var isPasswordFocused: Bool
+    let cornerRadius: CGFloat = 8
+
     var body: some View {
         HStack {
             Image(systemName: "key.fill")
                 .foregroundStyle(.secondary)
             
-            if showPassword {
+            ZStack { // Use opacity to toggle visibilty so that keyboard does not dismiss
                 TextField("Password", text: $password)
                     .textContentType(.password)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
-            } else {
+                    .focused($isPasswordFocused)
+                    .opacity(showPassword ? 1 : 0)
                 SecureField("Password", text: $password)
                     .textContentType(.password)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
+                    .focused($isPasswordFocused)
+                    .opacity(showPassword ? 0 : 1)
             }
             
-            Button(action: { showPassword.toggle() }) {
+            Button {
+                showPassword.toggle()
+                isPasswordFocused = true  // maintain keyboard focus
+            } label: {
                 Image(systemName: showPassword ? "eye.slash.fill" : "eye.fill")
                     .foregroundStyle(.secondary)
             }
         }
         .padding()
-        .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.2)))
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(Color.gray.opacity(0.2))
+                .contentShape(RoundedRectangle(cornerRadius: cornerRadius)) // Allow transparent pixels to be tappable
+        )
+        .onTapGesture {
+            isPasswordFocused = true // Expand touch area to border padding
+        }
     }
 }
 

--- a/Mage/UsernameFieldView.swift
+++ b/Mage/UsernameFieldView.swift
@@ -12,6 +12,8 @@ struct UsernameFieldView: View {
     @Binding var username: String
     var isDisabled: Bool = false
     var isLoading: Bool = false
+    let cornerRadius: CGFloat = 8
+    @FocusState private var isTextFieldFocused: Bool
     
     var body: some View {
         HStack {
@@ -24,9 +26,17 @@ struct UsernameFieldView: View {
                 .textContentType(.username)
                 .disabled(isDisabled || isLoading)
                 .opacity((isDisabled || isLoading) ? 0.6 : 1)
+                .focused($isTextFieldFocused)
         }
         .padding()
-        .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.2)))
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(Color.gray.opacity(0.2))
+                .contentShape(RoundedRectangle(cornerRadius: cornerRadius)) // Required for touch on transparent pixels
+        )
+        .onTapGesture { // Expand the touch area to the background shape
+            isTextFieldFocused = true
+        }
     }
 }
 


### PR DESCRIPTION
-  Username users a larger tap target
- Password users a larger tap target
- Show/hide password field does not dismiss keyboard when toggling

## Previous

https://github.com/user-attachments/assets/1ef952ec-42f0-4299-aa91-9e406d573fe5

## Fix

https://github.com/user-attachments/assets/ce3d62a0-923d-4f21-997c-89eb9a897922

