### PR TITLE
1613 - converting to uncompressed jpeg instead of broken png

### DIFF
--- a/Mage/Routing/MageNavStack.swift
+++ b/Mage/Routing/MageNavStack.swift
@@ -263,9 +263,9 @@ class MageNavStack: UIViewController {
                 cache.retrieveImage(forKey: cacheKey) { result in
                     switch result {
                     case .success(let value):
-                        if let image = value.image, let imageData = image.pngData() {
+                        if let image = value.image, let imageData = image.jpegData(compressionQuality: 1) {
                             let docsUrl = URL.documentsDirectory
-                            let filename = docsUrl.appendingPathComponent("image.png")
+                            let filename = docsUrl.appendingPathComponent("image.jpg")
                             
                             try? imageData.write(to: filename)
                             


### PR DESCRIPTION
# Problem
- So the problem was not the filetype on the phone or the server. It was that the data that was stored on the phone, regardless of where the image came from, was stored as just plain data without extension.
The fix, *Paul found it*, was that ***when being presented*** it was being converted with this function `.pngData()` every time. It was causing the irregular bloating of data to occur.

## Fix
- pngData() function was causing conversion of image data to bloat irregularly.
- now converting to jpeg @ compression level 1
  + example: original image was 20MB PNG, converted image to JPEG at 6MB