### PR TITLE
1552 - password mismatch error messages fixed

### DIFF
--- a/Mage/SignUpViewController.m
+++ b/Mage/SignUpViewController.m
@@ -216,6 +216,17 @@
     return YES;
 }
 
+- (void)textFieldDidChangeSelection:(UITextField *)textField {
+    // Password fields do not match
+    if (_password.text.length > 0 && ![_passwordConfirm.text isEqualToString:_password.text]) {
+        [self markFieldError:self.passwordConfirm errorText:@"Passwords Do Not Match"];
+    } else if (_passwordConfirm.text.length > 0 && ![_passwordConfirm.text isEqualToString:_password.text]) {
+        [self markFieldError:self.password errorText:@"Passwords Do Not Match"];
+    } else if ([_passwordConfirm.text isEqualToString:_password.text]) {
+        [self clearPasswordErrors];
+    }
+}
+
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     
     if (textField == _phone) {
@@ -382,6 +393,13 @@
 
 - (IBAction) onCancel:(id) sender {
     [self.delegate signupCanceled];
+}
+
+- (void) clearPasswordErrors {
+    self.password.leadingAssistiveLabel.text = @" ";
+    self.passwordConfirm.leadingAssistiveLabel.text = @" ";
+    [self.password applyThemeWithScheme:self.scheme];
+    [self.passwordConfirm applyThemeWithScheme:self.scheme];
 }
 
 - (void) clearFieldErrors {

--- a/Mage/SignUpViewController.m
+++ b/Mage/SignUpViewController.m
@@ -217,12 +217,36 @@
 }
 
 - (void)textFieldDidChangeSelection:(UITextField *)textField {
-    // Password fields do not match
-    if (_password.text.length > 0 && ![_passwordConfirm.text isEqualToString:_password.text]) {
-        [self markFieldError:self.passwordConfirm errorText:@"Passwords Do Not Match"];
-    } else if (_passwordConfirm.text.length > 0 && ![_passwordConfirm.text isEqualToString:_password.text]) {
-        [self markFieldError:self.password errorText:@"Passwords Do Not Match"];
-    } else if ([_passwordConfirm.text isEqualToString:_password.text]) {
+    NSString *password = self.password.text;
+    NSString *confirm = self.passwordConfirm.text;
+    
+    BOOL passwordEmpty = (password.length == 0);
+    BOOL confirmEmpty = (confirm.length == 0);
+    BOOL match = [password isEqualToString:confirm];
+    
+    if (passwordEmpty && confirmEmpty) {
+        [self clearPasswordErrors];
+        return;
+    }
+    
+    if (!passwordEmpty && confirmEmpty) {
+        [self clearPasswordErrors];
+        return;
+    }
+    
+    if (passwordEmpty && !confirmEmpty) {
+        [self clearPasswordErrors];
+        [self markFieldError:self.password errorText:@"Enter password first"];
+        return;
+    }
+    
+    if (!passwordEmpty && !confirmEmpty && !match) {
+        [self clearPasswordErrors];
+        [self markFieldError:self.passwordConfirm errorText:@"Passwords do not match"];
+        return;
+    }
+    
+    if (match) {
         [self clearPasswordErrors];
     }
 }
@@ -396,7 +420,7 @@
 }
 
 - (void) clearPasswordErrors {
-    self.password.leadingAssistiveLabel.text = @" ";
+    self.password.leadingAssistiveLabel.text = @" "; // String literal must be prefixed by '@'
     self.passwordConfirm.leadingAssistiveLabel.text = @" ";
     [self.password applyThemeWithScheme:self.scheme];
     [self.passwordConfirm applyThemeWithScheme:self.scheme];

--- a/Mage/SignUpViewController.m
+++ b/Mage/SignUpViewController.m
@@ -224,23 +224,18 @@
     BOOL confirmEmpty = (confirm.length == 0);
     BOOL match = [password isEqualToString:confirm];
     
-    if (passwordEmpty && confirmEmpty) {
+    if (confirmEmpty) { // no text entered && we don't want to show confirm error pre-emptively
         [self clearPasswordErrors];
         return;
     }
     
-    if (!passwordEmpty && confirmEmpty) {
-        [self clearPasswordErrors];
-        return;
-    }
-    
-    if (passwordEmpty && !confirmEmpty) {
+    if (passwordEmpty && !confirmEmpty) { // they skipped or deleted the password
         [self clearPasswordErrors];
         [self markFieldError:self.password errorText:@"Enter password first"];
         return;
     }
     
-    if (!passwordEmpty && !confirmEmpty && !match) {
+    if (!passwordEmpty && !confirmEmpty && !match) { // standard mismatch
         [self clearPasswordErrors];
         [self markFieldError:self.passwordConfirm errorText:@"Passwords do not match"];
         return;


### PR DESCRIPTION
# Signup Password Mismatch Error Messages
- If you make a mistake on the password match and try to correct it, the error messages do not reset when matching passwords are typed. The user has to press "Go" or scroll down to "Sign Up" button to clear the message and create an account.

## Fix
- `textFieldDidChangeSelection` used to watch password changes and toggle error messages accordingly

<img width="240" alt="none" src="https://github.com/user-attachments/assets/3689f696-c1dc-4e80-aff8-820c41186a1f" />
<img width="240" alt="clicked into confirm" src="https://github.com/user-attachments/assets/fce6e2bd-072c-4866-b19b-d5008b26481f" />
<img width="240" alt="basic mismatch" src="https://github.com/user-attachments/assets/8600b030-cb14-4c4a-899e-4b0fab1cb315" />
<img width="240" alt="matching" src="https://github.com/user-attachments/assets/ee73fdd1-c0a2-43ef-bf14-c4ae00aa1055" />
<img width="240" alt="missing password" src="https://github.com/user-attachments/assets/e7642a34-df68-4efd-a20b-a44abd9f1ecd" />

