### PR TITLE
MAGE-1695 Fixes intermittent crash on event switch

### DIFF
--- a/Mage/HasMapSearchMixin.swift
+++ b/Mage/HasMapSearchMixin.swift
@@ -61,7 +61,7 @@ class HasMapSearchMixin: NSObject, MapMixin {
     }
     
     func removeMixin(mapView: MKMapView, mapState: MapState) {
-
+        cancelSubscriptions()
     }
 
     func updateMixin(mapView: MKMapView, mapState: MapState) {
@@ -94,7 +94,13 @@ class HasMapSearchMixin: NSObject, MapMixin {
     }
     
     func cleanupMixin() {
-        self.searchController.dismiss(animated: true)
+        cancelSubscriptions() // MAGE-1695 Prevents event switch crash (always cleanup subscriptions)
+        searchController.dismiss(animated: true)
+    }
+    
+    func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
     }
     
     @objc func mapSearchButtonTapped(_ sender: UIButton) {


### PR DESCRIPTION
- Subscription was not canceled after a mixin was cleanedUp, which could result in crashes accessing deallocated UI elements.
- We need to make sure subscriptions are canceled when views, view controllers, or controller objects go out of scope

Without this protection, randomly we could see crashes in `updateViews()` which is triggered by the publisher subscription we need to cancel. The UI objects were deallocated.

<img width="705" height="930" alt="2025-11-17 Justin Connelly Crash on Event Change" src="https://github.com/user-attachments/assets/d0fbb6b3-0453-4abf-be4d-5173a3728365" />

Found by using the crash logs from TestFlight. 

<img width="705" height="828" alt="2025-11-17 Event Switch Crash - 4" src="https://github.com/user-attachments/assets/7d5226b3-5a72-4739-9c13-391cd1b26581" />
