### PR TITLE
MAGE-1695 Fixes intermittent crash on event switch

### DIFF
--- a/Mage/HasMapSearchMixin.swift
+++ b/Mage/HasMapSearchMixin.swift
@@ -61,7 +61,7 @@ class HasMapSearchMixin: NSObject, MapMixin {
     }
     
     func removeMixin(mapView: MKMapView, mapState: MapState) {
-
+        cancelSubscriptions()
     }
 
     func updateMixin(mapView: MKMapView, mapState: MapState) {
@@ -94,7 +94,13 @@ class HasMapSearchMixin: NSObject, MapMixin {
     }
     
     func cleanupMixin() {
-        self.searchController.dismiss(animated: true)
+        cancelSubscriptions() // MAGE-1695 Prevents event switch crash (always cleanup subscriptions)
+        searchController.dismiss(animated: true)
+    }
+    
+    func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
     }
     
     @objc func mapSearchButtonTapped(_ sender: UIButton) {


### PR DESCRIPTION
- Subscription was not canceled after a mixin was cleanedUp, which could result in crashes accessing deallocated UI elements.
- We need to make sure subscriptions are canceled when views, view controllers, or controller objects go out of scope