### PR TITLE
Mage-1702: Fixes a random crash in ObservationIconCoreDataDataSource from switching events

### DIFF
--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -111,7 +111,7 @@ class ObservationsMap: DataSourceMap {
                     if let eventId = event.remoteId, eventId == Server.currentEventId() {
                         guard let self = self else { return }
                         Task { [self] in
-                            self.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
+                            await self.iconRepository.resetEventIconSize(eventId: Int(truncating: eventId))
                             await self.repository.clearCache()
                             await self.redrawFeatures()
                             await MainActor.run {

--- a/Mage/Repository/Observation/Icon/ObservationIconLocalDataSource.swift
+++ b/Mage/Repository/Observation/Icon/ObservationIconLocalDataSource.swift
@@ -21,47 +21,35 @@ extension InjectedValues {
 
 protocol ObservationIconLocalDataSource {
     func getMaximumIconHeightToWidthRatio(eventId: Int) async -> CGSize
-    func resetEventIconSize(eventId: Int)
+    func resetEventIconSize(eventId: Int) async
 }
 
-class ObservationIconCoreDataDataSource: ObservationIconLocalDataSource {
+/// Uses an actor to maintain thread safe access to shared state
+actor ObservationIconCoreDataDataSource: ObservationIconLocalDataSource {
     @Injected(\.observationLocalDataSource)
     var localDataSource: ObservationLocalDataSource
     
     var iconSizePerEvent: [Int: CGSize] = [:]
     
-    let queue = DispatchQueue(label: "Queue")
-
-    @MainActor
     func getMaximumIconHeightToWidthRatio(eventId: Int) async -> CGSize {
-        if let eventIconSize = iconSizePerEvent[eventId] {
-            return eventIconSize
-        }
-        
-        return await withCheckedContinuation { continuation in
-            // doing this to synchronize access to the size
-            // see: https://www.donnywals.com/an-introduction-to-synchronizing-access-with-swifts-actors/
-            queue.async {
-                if let iconSize = self.iconSizePerEvent[eventId] {
-                    continuation.resume(returning: iconSize)
-                } else {
-                    // start with the default marker
-                    var size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: 0)
-                    if let defaultMarker = UIImage(named: "defaultMarker") {
-                        size = defaultMarker.size
-                    }
-                    let iconSize = self.iterateIconDirectoriesAtRoot(
-                        directory: self.rootIconFolder(eventId: eventId),
-                        currentLargest: size
-                    )
-                    self.iconSizePerEvent[eventId] = iconSize
-                    continuation.resume(returning: iconSize)
-                }
+        if let iconSize = iconSizePerEvent[eventId] {
+            return iconSize
+        } else {
+            // start with the default marker
+            var size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: 0)
+            if let defaultMarker = UIImage(named: "defaultMarker") {
+                size = defaultMarker.size
             }
-          }
+            let iconSize = iterateIconDirectoriesAtRoot(
+                directory: rootIconFolder(eventId: eventId),
+                currentLargest: size
+            )
+            iconSizePerEvent[eventId] = iconSize
+            return iconSize
+        }
     }
     
-    func resetEventIconSize(eventId: Int) {
+    func resetEventIconSize(eventId: Int) async {
         iconSizePerEvent.removeValue(forKey: eventId)
     }
 

--- a/Mage/Repository/Observation/Icon/ObservationIconRepository.swift
+++ b/Mage/Repository/Observation/Icon/ObservationIconRepository.swift
@@ -26,23 +26,17 @@ class ObservationIconRepository: ObservableObject {
     
     init() {
         if let currentEventId = Server.currentEventId() {
-            self.resetEventIconSize(eventId: Int(truncating: currentEventId))
+            Task {
+                await self.resetEventIconSize(eventId: Int(truncating: currentEventId))
+            }
         }
     }
-
-//    func getIconPath(observationUri: URL) async -> String? {
-//        await localDataSource.getIconPath(observationUri: observationUri)
-//    }
-//
-//    func getIconPath(observation: Observation) -> String? {
-//        localDataSource.getIconPath(observation: observation)
-//    }
 
     func getMaximumIconHeightToWidthRatio(eventId: Int) async -> CGSize {
         await localDataSource.getMaximumIconHeightToWidthRatio(eventId: eventId)
     }
     
-    func resetEventIconSize(eventId: Int) {
-        localDataSource.resetEventIconSize(eventId: eventId)
+    func resetEventIconSize(eventId: Int) async {
+        await localDataSource.resetEventIconSize(eventId: eventId)
     }
 }


### PR DESCRIPTION
Fixes a random crash in ObservationIconCoreDataDataSource from switching events

[Mage-1702: Switching Events Crash - iconSizePerEvent Dictionary Not Thread Safe](https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1702)

- The fix uses actor to protect shared state access and mutation.
- The crash was a race condition because shared state (dictionary) was modified from foreground and background threads
- Crashes manifested like: -[NSIndexPath objectForKey:]: unrecognized selector sent to instance 0x8000000000000000

<img width="600" height="1438" alt="2025-11-19 Crash on ObservationIconLocalDataSource dictionary iconSizePerEvent" src="https://github.com/user-attachments/assets/1c88b208-d794-414a-bf23-6f0c03e81ff1" />
