### PR TITLE
Mage-1690: Core Data Concurrency Debug Fixes

### DIFF
--- a/Mage/Repository/Layer/LayerLocalDataSource.swift
+++ b/Mage/Repository/Layer/LayerLocalDataSource.swift
@@ -25,22 +25,25 @@ protocol LayerLocalDataSource: Actor {
     func markRemoteLayerLoaded(remoteId: NSNumber)
     func createGeoPackageLayer(name: String) async -> Layer?
     func removeOutdatedOfflineMapArchives()
-    func count(eventId: NSNumber, layerId: Int) -> Int
+    func count(eventId: NSNumber, layerId: Int) async -> Int
 }
 
 actor LayerLocalCoreDataDataSource: LayerLocalDataSource {
     @Injected(\.nsManagedObjectContext)
     var context: NSManagedObjectContext?
     
-    func count(eventId: NSNumber, layerId: Int) -> Int {
-        let count = try? context?.countOfObjects(
-            Layer.self,
-            predicate: NSPredicate(
-                format: "eventId == %@ AND remoteId == %@", eventId, NSNumber(value:layerId)
-            )
-        )
+    func count(eventId: NSNumber, layerId: Int) async -> Int {
+        guard let context else { return 0 }
         
-        return count ?? 0
+        return await context.perform {
+            let count = try? context.countOfObjects(
+                Layer.self,
+                predicate: NSPredicate(
+                    format: "eventId == %@ AND remoteId == %@", eventId, NSNumber(value:layerId)
+                )
+            )
+            return count ?? 0
+        }
     }
     
     func createLoadedXYZLayer(name: String) async -> Layer? {

--- a/Mage/Repository/Settings/SettingsLocalDataSource.swift
+++ b/Mage/Repository/Settings/SettingsLocalDataSource.swift
@@ -50,22 +50,26 @@ class SettingsLocalDataSourceImpl: CoreDataDataSource<Settings>, SettingsLocalDa
     
     func setUpSettingsFetchedResultsController() {
         guard let context else { return }
-        let fetchRequest: NSFetchRequest<Settings> = Settings.fetchRequest()
-        fetchRequest.predicate = NSPredicate(value: true)
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "mapSearchUrl", ascending: false)]
-        
-        self.settingsResultsController = NSFetchedResultsController<Settings>(
-            fetchRequest: fetchRequest,
-            managedObjectContext: context,
-            sectionNameKeyPath: nil,
-            cacheName: nil
-        )
-        self.settingsResultsController?.delegate = self
-        try? self.settingsResultsController?.performFetch()
-        if let settings = self.settingsResultsController?.fetchedObjects,
-           let firstSettings = settings.first
-        {
-            settingsSubject.send(SettingsModel(settings: firstSettings))
+        context.perform { [weak self] in
+            guard let self else { return }
+            
+            let fetchRequest: NSFetchRequest<Settings> = Settings.fetchRequest()
+            fetchRequest.predicate = NSPredicate(value: true)
+            fetchRequest.sortDescriptors = [NSSortDescriptor(key: "mapSearchUrl", ascending: false)]
+            
+            self.settingsResultsController = NSFetchedResultsController<Settings>(
+                fetchRequest: fetchRequest,
+                managedObjectContext: context,
+                sectionNameKeyPath: nil,
+                cacheName: nil
+            )
+            self.settingsResultsController?.delegate = self
+            try? self.settingsResultsController?.performFetch()
+            if let settings = self.settingsResultsController?.fetchedObjects,
+               let firstSettings = settings.first
+            {
+                self.settingsSubject.send(SettingsModel(settings: firstSettings))
+            }
         }
     }
     

--- a/Mage/Repository/User/UserLocalDataSource.swift
+++ b/Mage/Repository/User/UserLocalDataSource.swift
@@ -63,12 +63,6 @@ class UserCoreDataDataSource: CoreDataDataSource<User>, UserLocalDataSource, Obs
     @Injected(\.roleLocalDataSource)
     var roleLocalDataSource: RoleLocalDataSource
     
-    private func getUserNSManagedObject(remoteId: String, context: NSManagedObjectContext) async -> User? {
-        return await context.perform {
-            return context.fetchFirst(User.self, key: UserKey.remoteId.key, value: remoteId)
-        }
-    }
-    
     private func getUserNSManagedObject(userUri: URL) async -> User? {
         guard let context = context else { return nil }
         return await context.perform {
@@ -76,6 +70,28 @@ class UserCoreDataDataSource: CoreDataDataSource<User>, UserLocalDataSource, Obs
                 return try? context.existingObject(with: id) as? User
             }
             return nil
+        }
+    }
+    
+    /**
+     * Safely fetches a User on its context and executes a closure of work.
+     *
+     * This wrapper ensures the 'User' object is always used on context.perform { } \\
+     *
+     * @param userUri The URL of the user to fetch.
+     * @param work A closure that receives the fetched 'User' and returns a value of type T.
+     * @return An optional value of type T
+     */
+    func withUser<T>(userUri: URL,
+                   perform work: @escaping (User) -> T) async -> T? {
+        guard let context = context else { return nil }
+        
+        return await context.perform {
+            guard let id = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: userUri),
+                  let user = try? context.existingObject(with: id) as? User else {
+                return nil
+            }
+            return work(user)
         }
     }
     
@@ -158,25 +174,26 @@ class UserCoreDataDataSource: CoreDataDataSource<User>, UserLocalDataSource, Obs
         event: EventModel,
         userUri: URL
     ) async -> Bool {
-        let user = await getUserNSManagedObject(userUri: userUri)
-                
-        if let userRemoteId = user?.remoteId,
-           let acl = event.acl,
-           let userAcl = acl[userRemoteId] as? [String : Any],
-           let userPermissions = userAcl[PermissionsKey.permissions.key] as? [String] {
-            if (userPermissions.contains(PermissionsKey.update.key)) {
-                return true
+        let canUpdateImportant = await withUser(userUri: userUri) { user in
+            if let userRemoteId = user.remoteId,
+               let acl = event.acl,
+               let userAcl = acl[userRemoteId] as? [String : Any],
+               let userPermissions = userAcl[PermissionsKey.permissions.key] as? [String] {
+                if (userPermissions.contains(PermissionsKey.update.key)) {
+                    return true
+                }
             }
-        }
-        
-        // if the user has UPDATE_EVENT permission
-        if let role = user?.role, let rolePermissions = role.permissions {
-            if rolePermissions.contains(PermissionsKey.UPDATE_EVENT.key) {
-                return true
+            
+            // if the user has UPDATE_EVENT permission
+            if let role = user.role, let rolePermissions = role.permissions {
+                if rolePermissions.contains(PermissionsKey.UPDATE_EVENT.key) {
+                    return true
+                }
             }
+            
+            return false
         }
-
-        return false
+        return canUpdateImportant ?? false
     }
     
     func avatarChosen(user: UserModel, imageData: Data) {


### PR DESCRIPTION
These Core Data fixes should improve stability when switching events and first launching the app. The Issues were identified with the `-com.apple.CoreData.ConcurrencyDebug 1` flag.

[Mage-1690: Fix Core Data Concurrency Errors](https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1690)

All Core Data usage needs to be on the main thread, and ideally in the `context.perform { }` to prevent accessing Core Data objects from foreground/background threads.

It is not safe to return Core Data objects, so any work needs to be restructured to happen on the perform closure.

**Fixed Issues**
* Settings Core Data Access
* LayerLocalCoreDataDataSource count (Frequent crash)
* UserLocalDataSource crash around users/roles (Frequent crash)