### PR TITLE
DEBUG ONLY: Enable Core Data assertions. Remove for release

### DIFF
--- a/MAGE.xcodeproj/xcshareddata/xcschemes/MAGE.xcscheme
+++ b/MAGE.xcodeproj/xcshareddata/xcschemes/MAGE.xcscheme
@@ -99,6 +99,16 @@
             ReferencedContainer = "container:MAGE.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.SQLDebug 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"
@@ -108,6 +118,21 @@
          <EnvironmentVariable
             key = "CFNETWORK_DIAGNOSTICS"
             value = "3"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SQLITE_ENABLE_THREAD_ASSERTIONS"
+            value = " 1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SQLITE_AUTO_TRACE"
+            value = "1"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SQLITE_ENABLE_FILE_ASSERTIONS"
+            value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/MAGE.xctestplan
+++ b/MAGE.xctestplan
@@ -18,10 +18,32 @@
         }
       ]
     },
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
+      },
+      {
+        "argument" : "-com.apple.CoreData.SQLDebug 1",
+        "enabled" : false
+      }
+    ],
     "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "SQLITE_AUTO_TRACE",
+        "value" : "1"
+      },
+      {
+        "key" : "SQLITE_ENABLE_THREAD_ASSERTIONS",
+        "value" : "1"
+      },
       {
         "key" : "OS_ACTIVITY_MODE",
         "value" : "enable"
+      },
+      {
+        "key" : "SQLITE_ENABLE_FILE_ASSERTIONS",
+        "value" : "1"
       },
       {
         "enabled" : false,


### PR DESCRIPTION
Enable Core Data assertions with `-com.apple.CoreData.ConcurrencyDebug 1` in Debug only.

* We should only merge after beta is finalize to help find invalid Core Data usage.
* IMPORTANT: We need to revert this before a release. 
* IMPORTANT: Only merge after we get fixes for: https://github.com/ngageoint/mage-ios/pull/196 (Otherwise we'll get false positives in `develop` branch)