### PR TITLE
WIP - Bottom Sheet Sizing Can Be Smaller on MapView

### DIFF
--- a/Mage/Mixins/BottomSheetEnabled.swift
+++ b/Mage/Mixins/BottomSheetEnabled.swift
@@ -74,7 +74,13 @@ class BottomSheetMixin: NSObject, MapMixin {
         let mageBottomSheet = SwiftUIViewController(swiftUIView: MageBottomSheet())
         mageBottomSheet.modalPresentationStyle = .pageSheet
         if let sheet = mageBottomSheet.sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
+            sheet.detents = [
+                .medium(),
+                .large(),
+                .custom(resolver: { context in
+                    return 220 // FIXME: Do we use all these custom sizes? Or should we pick one? ~220 is close to previous behavior. Why doesn't this "self size"?
+                })
+            ]
         }
         self.bottomSheetEnabled.navigationController?.present(mageBottomSheet, animated: true, completion: nil)
         


### PR DESCRIPTION
FIXME: Can it self size, or do we always need the small view? Does Feed Item vs Location show different content?

More investigation if we want to fix this issue with SwiftUI sheet presentation. 

I assume previous 4.2.0 (4.0.7) logic was self sizing, but SwiftUI implementation is not.

WIP Logic allows a smaller detent, but we need to make sure all types of content fit within a smaller size, or we need logic to self-size this so we always display all the content without clipping it.

## With 220 point height:

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-08 at 12 19 31" src="https://github.com/user-attachments/assets/24c2baf6-8172-4da8-abd4-eae26e5d26c1" />

## With .medium detent

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-08 at 12 26 17" src="https://github.com/user-attachments/assets/c3c2817a-93db-4abe-8638-ccac35e85833" />
