### PR TITLE
WIP - Mage-1722: Fix place name search map view zoom

### DIFF
--- a/Mage/Geocoder.swift
+++ b/Mage/Geocoder.swift
@@ -7,7 +7,8 @@
 //
 
 import Foundation
-
+import MapKit
+import CoreLocation
 import GARS
 import MGRS
 
@@ -26,6 +27,7 @@ class GeocoderResult {
     var name: String
     var address: String? = nil
     var location: CLLocationCoordinate2D? = nil
+    var region: MKCoordinateRegion? = nil
     
     init(name: String, address: String? = nil, location: CLLocationCoordinate2D? = nil) {
         self.name = name

--- a/Mage/NativeService.swift
+++ b/Mage/NativeService.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MapKit
+import CoreLocation
 
 class NativeService {
     func search(text: String, region: MKCoordinateRegion? = nil, completion: @escaping ((SearchResponse) -> Void)) {
@@ -35,7 +36,27 @@ class NativeService {
                     placemark.countryCode
                 ].compactMap { $0 }.joined(separator: ", ")
 
-                return GeocoderResult(name: placemark.name ?? text, address: address, location: placemark.location?.coordinate)
+                // FIXME: Experimental code to explore changing the region displayed so that Fiji can fill the entire map, rather than the ocean at "street view" (wrong zoom level for a country)
+//                return GeocoderResult(name: placemark.name ?? text, address: address, location: placemark.location?.coordinate)
+                var result = GeocoderResult(name: placemark.name ?? text, address: address, location: placemark.location?.coordinate)
+//                result.region = placemark.region
+                
+                
+                
+//                var itemRegion: MKCoordinateRegion? = nil
+                    
+                if let circularRegion = placemark.region as? CLCircularRegion { // FIXME: CLCircularRegion deprecated use CLCircularGeographicCondition on iOS 17+ (dependent on upping the min version for next release)
+                        // Convert the circle's radius (meters) to a Map Span (degrees)
+                        // Rule of thumb: 1 degree of latitude is ~111,000 meters
+                        let diameter = circularRegion.radius * 2.0
+                        let degrees = diameter / 111000.0
+                        
+                        // Add a little padding (1.2x)
+                        let span = MKCoordinateSpan(latitudeDelta: degrees * 1.5, longitudeDelta: degrees * 1.5)
+                        result.region = MKCoordinateRegion(center: placemark.coordinate, span: span)
+                    }
+                
+                return result
             }
             
             completion(SearchResponse.success(type: .geocoder, results: results))

--- a/Mage/NominatimService.swift
+++ b/Mage/NominatimService.swift
@@ -38,6 +38,13 @@ class NominatimService {
                     let location = geometry?.degreesCentroid().map { centroid in
                         CLLocationCoordinate2D(latitude: centroid.y.doubleValue, longitude: centroid.x.doubleValue)
                     }
+
+                    if let bbox = feature["bbox"] as? [Double] {
+                        // FIXME: Nominatim/GeoJSON usually provides bbox as [minLon, minLat, maxLon, maxLat], we'd need to use similar logic to Native service for properly containing point of interest at it's natural zoom level via the bbox
+                        // Store it in properties so your UI can find it later
+//                            properties["bbox"] = bbox
+                        print(bbox)
+                    }
                     
                     return GeocoderResult(name: name, address: address, location: location)
                 }) ?? []


### PR DESCRIPTION
Logic not final, just placeholder areas to dig. I had this working at one point, but broke it. Requires server to be set to Native vs. Nominatim. I only prototyped logic for Native with test.mage.geointapps.com

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1722

Current issue is that searching for "Fiji" results in ocean.

<img width="300" alt="Screenshot 2025-12-08 at 12 35 37 PM" src="https://github.com/user-attachments/assets/82a9e0b4-d1fb-4900-8e9b-4590030b3428" />

We expect to see the entire Island. I think this is an issue of using `.centroid` instead of the bbox or `.evelope()` that we store in the min/max lat and long coordinates.

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-08 at 12 47 10" src="https://github.com/user-attachments/assets/877293c5-203b-4de7-b897-3f62f69e73a0" />
