### PR TITLE
Mage-1725 Map Refresh Too Often Causing Lag

### DIFF
--- a/MAGE.xcodeproj/project.pbxproj
+++ b/MAGE.xcodeproj/project.pbxproj
@@ -1952,6 +1952,11 @@
 			path = IntroViews;
 			sourceTree = "<group>";
 		};
+		BD16DD222EE88F1C00F90354 /* Helpers */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3635,6 +3640,7 @@
 				2F9B48DD1ED3BCC1001D07AB /* MageOfflineObservationManager.m */,
 				F7994AB6190EF7BD00A90A1D /* MageRootViewController.swift */,
 				F72C175E2523B82500682052 /* MageUserDefaultKeys.swift */,
+				BD16DD222EE88F1C00F90354 /* Helpers */,
 				4C546FE9195A27D1000CF230 /* Map */,
 				F739682F2460B0290017D481 /* MaterialComponents */,
 				F7AA61AE27A9E73400D617B7 /* Media */,
@@ -4350,6 +4356,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				A811F2832E3BEAF80016C5AB /* IntroViews */,
+				BD16DD222EE88F1C00F90354 /* Helpers */,
 			);
 			name = MAGE;
 			packageProductDependencies = (

--- a/Mage/Helpers/UserDefaults+Publisher.swift
+++ b/Mage/Helpers/UserDefaults+Publisher.swift
@@ -1,0 +1,32 @@
+//
+//  UserDefaults+Publisher.swift
+//  MAGE
+//
+//  Created by Paul Solt on 12/9/25.
+//  Copyright © 2025 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+    
+    /// A publisher that fires when settings change on UserDefaults. Use this to reduce unwanted updates
+    /// and combine with `Publisher.mergeMany([])` to group related settings changes into one event stream.
+    ///
+    /// - Only fires when values change. It ignores initial state and duplicate changes (Assigning the same value)
+    /// - The type is erased and standardized so that it can be used with `Publisher.mergeMany([])`
+    ///
+    /// - Parameter keyPath: The `KeyPath` to the specific `UserDefaults` property to observe.
+    /// - Returns: An `AnyPublisher<Void, Never>` that fires only when the settings value actually changes.
+    func settingsChangePublisher<T: Equatable>(_ keyPath: KeyPath<UserDefaults, T>) -> AnyPublisher<Void, Never> {
+            publisher(for: keyPath)
+                .dropFirst()
+                .removeDuplicates()
+                .handleEvents(receiveOutput: { newValue in
+                    MageLogger.misc.debug("Setting changed: \(String(describing: keyPath)) -> \(String(describing: newValue))")
+                })
+                .map { _ in }
+                .eraseToAnyPublisher()
+    }
+}

--- a/Mage/Mixins/DataSourceMap.swift
+++ b/Mage/Mixins/DataSourceMap.swift
@@ -164,50 +164,40 @@ class DataSourceMap: MapMixin {
     @MainActor
     func handleFeatureChanges(annotations: [DataSourceAnnotation]) -> Bool {
         guard let mapView = mapView else { return false }
+        let annotationDictionary = [String : DataSourceAnnotation]()
         
-        let existingAnnotations = mapView.annotations.compactMap({ annotation in
+        // Create a dictionary lookup so we don't fall into a O(n^2) complexity issue on inserts/removes
+        let existingAnnotations = mapView.annotations.compactMap { annotation in
             (annotation as? DataSourceAnnotation)
-        }).filter({ annotation in
+        }
+        .filter { annotation in
             annotation.dataSource.key == self.dataSource.key
-        }).sorted(by: { first, second in
-            first.id < second.id
-        })
-        
-        // this is how to create the annotations array from the previous annotations array
-        let differences = annotations.difference(from: existingAnnotations) { annotation1, annotation2 in
-            annotation1.id == annotation2.id
+        }
+        .reduce(into: annotationDictionary) { dictionary, annotation in
+            dictionary[annotation.id] = annotation
         }
         
         var inserts: [DataSourceAnnotation] = []
         var removals: [DataSourceAnnotation] = []
-        for change in differences {
-            switch change {
-            case .insert(_, let element, _):
-                let existing = mapView.annotations.first(where: { mapAnnotation in
-                    guard let mapAnnotation = mapAnnotation as? DataSourceAnnotation else {
-                        return false
-                    }
-                    return mapAnnotation.id == element.id
-                }) as? DataSourceAnnotation
-                if let existing = existing {
-                    existing.coordinate = element.coordinate
-                } else {
-                    inserts.append(element)
-                }
-            case .remove(_, let element, _):
-                let existing = mapView.annotations.compactMap({ mapAnnotation in
-                    mapAnnotation as? DataSourceAnnotation
-                }).filter({ mapAnnotation in
-                    if mapAnnotation.id == element.id {
-                        currentAnnotationViews.removeValue(forKey: mapAnnotation.id)
-                        return true
-                    }
-                    return false
-                })
-                removals.append(contentsOf: existing)
+
+        // Update or prepare to insert annotations
+        for annotation in annotations {
+            if let existing = existingAnnotations[annotation.id] {
+                existing.coordinate = annotation.coordinate
+            } else {
+                inserts.append(annotation)
             }
         }
         
+        // Prepare to remove observations
+        let newIds = Set(annotations.map { $0.id })
+        for (id, existingAnnotation) in existingAnnotations {
+            if !newIds.contains(id) {
+                removals.append(existingAnnotation)
+                currentAnnotationViews.removeValue(forKey: id) // FIXME: Refactor/remove currentAnnotationViews. We should not maintain a collection that could get out of date from MapKit
+            }
+        }
+                
         mapView.addAnnotations(inserts)
         mapView.removeAnnotations(removals)
         

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -191,7 +191,7 @@ class ObservationsMap: DataSourceMap {
 //            annotationView.canShowCallout = true
         }
         mapItemAnnotation.annotationView = annotationView
-        currentAnnotationViews[mapItemAnnotation.id] = annotationView
+        currentAnnotationViews[mapItemAnnotation.id] = annotationView // FIXME: Refactor/remove currentAnnotationViews. We should not maintain a collection that could get out of date from MapKit
         return annotationView
     }
 }

--- a/Mage/Observation/ObservationsMap.swift
+++ b/Mage/Observation/ObservationsMap.swift
@@ -6,9 +6,11 @@
 //  Copyright © 2024 National Geospatial Intelligence Agency. All rights reserved.
 //
 
+import Combine
 import Foundation
 import DataSourceTileOverlay
 import MapFramework
+
 
 class ObservationsMap: DataSourceMap {
     let OBSERVATION_MAP_ITEM_ANNOTATION_VIEW_REUSE_ID = "OBSERVATION_ICON"
@@ -37,84 +39,22 @@ class ObservationsMap: DataSourceMap {
             repository: repository,
             mapFeatureRepository: mapFeatureRepository
         )
-
-        UserDefaults.standard.publisher(for: \.hideObservations)
-            .removeDuplicates()
-            .sink { [weak self] show in
-                guard let self = self else { return }
-                Task { [self] in
-                    await self.repository.clearCache()
-                    await MainActor.run {
-                        self.viewModel?.refresh()
-                    }
-                }
-            }
-            .store(in: &cancellable)
-        UserDefaults.standard.publisher(for: \.observationTimeFilterKey)
-            .removeDuplicates()
-            .sink { [weak self] order in
-                NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
-                guard let self = self else { return }
-                Task { [self] in
-                    await self.repository.clearCache()
-                    await MainActor.run {
-                        self.viewModel?.refresh()
-                    }
-                }
-            }
-            .store(in: &cancellable)
-        UserDefaults.standard.publisher(for: \.observationTimeFilterUnitKey)
-            .removeDuplicates()
-            .sink { [weak self] order in
-                NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
-                guard let self = self else { return }
-                Task { [self] in
-                    await self.repository.clearCache()
-                    await MainActor.run {
-                        self.viewModel?.refresh()
-                    }
-                }
-            }
-            .store(in: &cancellable)
-        UserDefaults.standard.publisher(for: \.observationTimeFilterNumberKey)
-            .removeDuplicates()
-            .sink { [weak self] order in
-                NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
-                guard let self = self else { return }
-                Task { [self] in
-                    await self.repository.clearCache()
-                    await MainActor.run {
-                        self.viewModel?.refresh()
-                    }
-                }
-            }
-            .store(in: &cancellable)
-        UserDefaults.standard.publisher(for: \.importantFilterKey)
-            .removeDuplicates()
-            .sink { [weak self] order in
-                NSLog("Order update \(self?.dataSource.key ?? ""): \(order)")
-                guard let self = self else { return }
-                Task { [self] in
-                    await self.repository.clearCache()
-                    await MainActor.run {
-                        self.viewModel?.refresh()
-                    }
-                }
-            }
-            .store(in: &cancellable)
-        UserDefaults.standard.publisher(for: \.favoritesFilterKey)
-            .removeDuplicates()
-            .sink { [weak self] order in
-                guard let self = self else { return }
-                Task { [self] in
-                    await self.repository.clearCache()
-                    await MainActor.run {
-                        self.viewModel?.refresh()
-                    }
-                }
-            }
-            .store(in: &cancellable)
-
+       
+        let defaults = UserDefaults.standard
+        Publishers.MergeMany([ // Group all the settings into one publisher so we don't trigger on every property change
+            defaults.settingsChangePublisher(\.hideObservations),
+            defaults.settingsChangePublisher(\.observationTimeFilterKey),
+            defaults.settingsChangePublisher(\.observationTimeFilterUnitKey),
+            defaults.settingsChangePublisher(\.observationTimeFilterNumberKey),
+            defaults.settingsChangePublisher(\.importantFilterKey),
+            defaults.settingsChangePublisher(\.favoritesFilterKey)
+        ])
+        .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
+        .sink { [weak self] _ in
+            self?.refreshAll()
+        }
+        .store(in: &cancellable)
+        
         NotificationCenter.default.publisher(for: .MAGEFormFetched)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
@@ -143,9 +83,19 @@ class ObservationsMap: DataSourceMap {
             .store(in: &cancellable)
     }
 
+    private func refreshAll() {
+        Task {
+            await repository.clearCache()
+            await MainActor.run {
+                viewModel?.refresh()
+            }
+        }
+    }
+    
     func focusAnnotation(mapItem: ObservationMapItem?) {
         if !self.currentAnnotationViews.isEmpty {
             if let mapItem = mapItem {
+                
                 for annotationView in self.currentAnnotationViews.values {
                     if let annotation = annotationView.annotation as? DataSourceAnnotation {
                         if annotation.id != mapItem.observationLocationId?.absoluteString {


### PR DESCRIPTION
Reduces unwanted refresh "thrashing" on the main thread due to all the publishers. 

* Prevents all the settings from triggering redraws by combining the publishers
* And improves difference logic for large data set inserts/removes when panning or zooming. (O(n) instead of O(n^2) performance)

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1725

## Map Lag (O(n^2) work being done)

We do a ton of bookkeeping that has two nested loops. This is bad performance as the number of observations on the map scales.

https://github.com/user-attachments/assets/09da6cf2-565f-4f79-bc4d-b82d043a1339

## Map Less Laggy with Fixes

If we do some book keeping with a dictionary we can reduce a ton of work that doesn't need to happen. No nested loop, so we're closer to O(n) performance on a redraw.

https://github.com/user-attachments/assets/ce3836ff-5590-4088-bbe5-5634f43a9e0a
