### PR TITLE
MAGE-1718 Fixes the Map Locations on the Observation

### DIFF
--- a/Mage/CoreData/Observation.swift
+++ b/Mage/CoreData/Observation.swift
@@ -30,6 +30,8 @@ enum ObservationState: Int, CustomStringConvertible {
     
     public static let PRIMARY_OBSERVATION_GEOMETRY = "primary-observation-geometry"
 
+    var userDefaults = UserDefaults.standard    // Allow for injection since this is NSManagedObject
+    
     var orderedAttachments: [AttachmentModel]? {
         get {
             var observationForms: [[String: Any]] = []
@@ -87,14 +89,10 @@ enum ObservationState: Int, CustomStringConvertible {
 
     public func viewRegion(mapView: MKMapView) -> MKCoordinateRegion {
         if let geometry = self.geometry {
-            var latitudeMeters = 2500.0
-            var longitudeMeters = 2500.0
-            if geometry is SFPoint {
-                if let properties = properties, let accuracy = properties[ObservationKey.accuracy.key] as? Double {
-                    latitudeMeters = accuracy * 2.5
-                    longitudeMeters = accuracy * 2.5
-                }
-            } else {
+            var latitudeMeters = userDefaults.pointCoordinateSpan
+            var longitudeMeters = userDefaults.pointCoordinateSpan
+            
+            if geometry.geometryType != .POINT {
                 let envelope = SFGeometryEnvelopeBuilder.buildEnvelope(with: geometry)
                 let boundingBox = GPKGBoundingBox(envelope: envelope)
                 if let size = boundingBox?.sizeInMeters() {

--- a/Mage/GeometryView.swift
+++ b/Mage/GeometryView.swift
@@ -39,7 +39,7 @@ class GeometryView : BaseFieldView {
     
     lazy var mapView: SingleFeatureMapView = {
         let mapView = SingleFeatureMapView(observation: nil, scheme: scheme)
-        mapView.autoSetDimension(.height, toSize: editMode ? 150 : 200);
+        mapView.autoSetDimension(.height, toSize: 200) // keep a consistent size
 
         return mapView;
     }()

--- a/Mage/MageUserDefaultKeys.swift
+++ b/Mage/MageUserDefaultKeys.swift
@@ -30,6 +30,7 @@ extension Notification.Name {
     public static let MapRequestFocus = Notification.Name("MapRequestFocus")
     public static let AttachmentPushed = Notification.Name("AttachmentPushed")
     public static let ContactInfoDidChange = Notification.Name("ContactInfoDidChange")
+    public static let DefaultMapPointSpan = Notification.Name("DefaultMapPointSpan")
 }
 
 @objc public enum LocationDisplay : Int {
@@ -39,12 +40,31 @@ extension Notification.Name {
     case gars
 }
 
+public enum Defaults {
+    static let defaultPointCoordinateSpan: Double = 1000 // Previously 2,500 (FUTURE: User setting)
+}
+
+private extension String {
+    static let pointCoordinateSpan = "pointCoordinateSpan"
+}
+
 public enum MageDirectories: String {
     case cache = "MapCache"
 }
 
 public enum MageZooms: Int {
     case featureMaxZoom = 21
+}
+
+extension UserDefaults {
+    @objc var pointCoordinateSpan: Double {
+        get {
+            return double(forKey: .pointCoordinateSpan)
+        }
+        set {
+            setValue(newValue, forKey: .pointCoordinateSpan)
+        }
+    }
 }
 
 extension UserDefaults {

--- a/Mage/Map/MapAnnotationObservation.m
+++ b/Mage/Map/MapAnnotationObservation.m
@@ -42,16 +42,8 @@
 }
 
 -(MKCoordinateRegion) viewRegionOfMapView: (MKMapView *) mapView{
-    CLLocationDistance latitudeMeters = 2500;
-    CLLocationDistance longitudeMeters = 2500;
-    Observation *observation = [self observation];
-    NSDictionary *properties = observation.properties;
-    id accuracyProperty = [properties valueForKeyPath:@"accuracy"];
-    if (accuracyProperty != nil) {
-        double accuracy = [accuracyProperty doubleValue];
-        latitudeMeters = accuracy * 2.5;  // double the radius w/ padding
-        longitudeMeters = accuracy * 2.5; // double the radius w/ padding
-    }
+    CLLocationDistance latitudeMeters = NSUserDefaults.standardUserDefaults.pointCoordinateSpan;
+    CLLocationDistance longitudeMeters = NSUserDefaults.standardUserDefaults.pointCoordinateSpan;
     
     MKCoordinateRegion region = MKCoordinateRegionMakeWithDistance(_annotation.coordinate, latitudeMeters, longitudeMeters);
     return [mapView regionThatFits:region];

--- a/Mage/Mixins/SFGeometryMap.swift
+++ b/Mage/Mixins/SFGeometryMap.swift
@@ -77,12 +77,14 @@ class SFGeometryMapMixin: NSObject, MapMixin {
         var longitudeMeters = 2500.0
         if let geometry = sfGeometry {
 
-            let envelope = SFGeometryEnvelopeBuilder.buildEnvelope(with: geometry)
-            let boundingBox = GPKGBoundingBox(envelope: envelope)
-            if let size = boundingBox?.sizeInMeters() {
-                latitudeMeters = size.height + (2 * (size.height * 0.1))
-                longitudeMeters = size.width + (2 * (size.width * 0.1))
-                
+            if geometry.geometryType != .POINT { // Prevent incorrect point bounds
+                let envelope = SFGeometryEnvelopeBuilder.buildEnvelope(with: geometry)
+                let boundingBox = GPKGBoundingBox(envelope: envelope)
+                if let size = boundingBox?.sizeInMeters() {
+                    latitudeMeters = size.height + (2 * (size.height * 0.1))
+                    longitudeMeters = size.width + (2 * (size.width * 0.1))
+                    
+                }
             }
             
             if let centroid = geometry.centroid() {

--- a/Mage/Mixins/SFGeometryMap.swift
+++ b/Mage/Mixins/SFGeometryMap.swift
@@ -31,10 +31,12 @@ class SFGeometryMapMixin: NSObject, MapMixin {
         }
     }
     var geometryToShape: [SFGeometry : GPKGMapShape] = [:]
+    let userDefaults: UserDefaults
     
-    init(sfGeometryMap: SFGeometryMap, sfGeometry: SFGeometry?) {
+    init(sfGeometryMap: SFGeometryMap, sfGeometry: SFGeometry?, userDefaults: UserDefaults = .standard) {
         self.sfGeometryMap = sfGeometryMap
         self._sfGeometry = sfGeometry
+        self.userDefaults = userDefaults
     }
     
     func removeMixin(mapView: MKMapView, mapState: MapState) {
@@ -73,8 +75,8 @@ class SFGeometryMapMixin: NSObject, MapMixin {
     }
     
     func setMapRegion(sfGeometry: SFGeometry?) {
-        var latitudeMeters = 2500.0
-        var longitudeMeters = 2500.0
+        var latitudeMeters = userDefaults.pointCoordinateSpan
+        var longitudeMeters = userDefaults.pointCoordinateSpan
         if let geometry = sfGeometry {
 
             if geometry.geometryType != .POINT { // Prevent incorrect point bounds

--- a/Mage/Model/Observation/ObservationMapItem.swift
+++ b/Mage/Model/Observation/ObservationMapItem.swift
@@ -35,6 +35,8 @@ struct ObservationMapItem: Equatable, Hashable {
     var syncing: Bool = false
     var important: ObservationImportantModel?
 
+    let userDefaults: UserDefaults
+    
     var coordinate: CLLocationCoordinate2D? {
         guard let geometry = geometry, let point = geometry.centroid() else {
             return nil
@@ -93,15 +95,12 @@ struct ObservationMapItem: Equatable, Hashable {
     
     // The default map bounding area around a point or coordinate
     public func boundingRegion() -> MKCoordinateRegion {
+        print("Map Point Span: \(UserDefaults.standard.pointCoordinateSpan)")
         if let geometry = geometry {
-            var latitudeMeters = 2500.0
-            var longitudeMeters = 2500.0
-            if geometry is SFPoint {
-                if let accuracy = accuracy, accuracy != 0 {
-                    latitudeMeters = accuracy * 2.5
-                    longitudeMeters = accuracy * 2.5
-                }
-            } else {
+            var latitudeMeters = userDefaults.pointCoordinateSpan
+            var longitudeMeters = userDefaults.pointCoordinateSpan
+            
+            if geometry.geometryType != .POINT {
                 let envelope = SFGeometryEnvelopeBuilder.buildEnvelope(with: geometry)
                 let boundingBox = GPKGBoundingBox(envelope: envelope)
                 if let size = boundingBox?.sizeInMeters() {
@@ -118,7 +117,7 @@ struct ObservationMapItem: Equatable, Hashable {
 }
 
 extension ObservationMapItem {
-    init(observation: ObservationLocation) {
+    init(observation: ObservationLocation, userDefaults: UserDefaults = .standard) {
         self.observationId = observation.observation?.objectID.uriRepresentation()
         self.observationLocationId = observation.objectID.uriRepresentation()
         self.formId = Int(observation.formId)
@@ -151,5 +150,6 @@ extension ObservationMapItem {
                 self.important = ObservationImportantModel(observationImportant: observationImportant)
             }
         }
+        self.userDefaults = userDefaults
     }
 }

--- a/Mage/Model/Observation/ObservationMapItem.swift
+++ b/Mage/Model/Observation/ObservationMapItem.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+import GeoPackage
 import SimpleFeatures
+import CoreLocation
 
 struct ObservationMapItem: Equatable, Hashable {
     var observationId: URL?
@@ -87,6 +89,31 @@ struct ObservationMapItem: Equatable, Hashable {
             primaryFieldText: primaryFieldText,
             secondaryFieldText: secondaryFieldText
         )
+    }
+    
+    // The default map bounding area around a point or coordinate
+    public func boundingRegion() -> MKCoordinateRegion {
+        if let geometry = geometry {
+            var latitudeMeters = 2500.0
+            var longitudeMeters = 2500.0
+            if geometry is SFPoint {
+                if let accuracy = accuracy, accuracy != 0 {
+                    latitudeMeters = accuracy * 2.5
+                    longitudeMeters = accuracy * 2.5
+                }
+            } else {
+                let envelope = SFGeometryEnvelopeBuilder.buildEnvelope(with: geometry)
+                let boundingBox = GPKGBoundingBox(envelope: envelope)
+                if let size = boundingBox?.sizeInMeters() {
+                    latitudeMeters = size.height + (2 * (size.height * 0.1))
+                    longitudeMeters = size.width + (2 * (size.width * 0.1))
+                }
+            }
+            if let centroid = geometry.centroid() {
+                return MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: centroid.y.doubleValue, longitude: centroid.x.doubleValue), latitudinalMeters: latitudeMeters, longitudinalMeters: longitudeMeters)
+            }
+        }
+        return MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 0, longitude: 0), latitudinalMeters: 50000, longitudinalMeters: 50000)
     }
 }
 

--- a/Mage/ObservationLocationFieldView.swift
+++ b/Mage/ObservationLocationFieldView.swift
@@ -33,8 +33,11 @@ struct ObservationLocationFieldView: View {
         .onChange(of: observationUri) { observationUri in
             viewModel.observationUri = observationUri
         }
-        .onChange(of: viewModel.selectedItem) { selectedItem in
-            mapState.coordinateCenter = viewModel.currentItem?.coordinate
+        .onChange(of: viewModel.currentItemIndex) { selectedItem in
+            updateMap()
+        }
+        .onChange(of: viewModel.observationMapItems) { newMapItems in
+            updateMap()
         }
         .onAppear {
             viewModel.observationUri = observationUri
@@ -46,6 +49,13 @@ struct ObservationLocationFieldView: View {
                 observationFormId: observationFormId,
                 fieldName: fieldName
             )))
+        }
+    }
+    
+    func updateMap() {
+        if let currentItem = viewModel.currentItem {
+            let region = currentItem.boundingRegion()
+            mapState.centerRegion = region
         }
     }
 
@@ -70,9 +80,7 @@ struct ObservationLocationFieldView: View {
             } else if viewModel.observationMapItems.count > 1 {
                 Button(
                     action: {
-                        withAnimation {
-                            viewModel.selectedItem = max(0, viewModel.selectedItem  - 1)
-                        }
+                        viewModel.currentItemIndex = max(0, viewModel.currentItemIndex  - 1)
                     },
                     label: {
                         Label(
@@ -80,7 +88,7 @@ struct ObservationLocationFieldView: View {
                             icon: {
                                 Image(systemName: "chevron.left")
                                     .renderingMode(.template)
-                                    .foregroundColor(viewModel.selectedItem  != 0
+                                    .foregroundColor(viewModel.currentItemIndex  != 0
                                                      ? Color.primaryColorVariant : Color.disabledColor
                                     )
                             })
@@ -102,9 +110,7 @@ struct ObservationLocationFieldView: View {
                 }
                 Button(
                     action: {
-                        withAnimation {
-                            viewModel.selectedItem = min(viewModel.observationMapItems.count - 1, viewModel.selectedItem + 1)
-                        }
+                        viewModel.currentItemIndex = min(viewModel.observationMapItems.count - 1, viewModel.currentItemIndex + 1)
                     },
                     label: {
                         Label(
@@ -112,7 +118,7 @@ struct ObservationLocationFieldView: View {
                             icon: {
                                 Image(systemName: "chevron.right")
                                     .renderingMode(.template)
-                                    .foregroundColor(viewModel.observationMapItems.count - 1 != viewModel.selectedItem
+                                    .foregroundColor(viewModel.observationMapItems.count - 1 != viewModel.currentItemIndex
                                                      ? Color.primaryColorVariant : Color.disabledColor)
                             })
                     }

--- a/Mage/ObservationLocationFieldViewModel.swift
+++ b/Mage/ObservationLocationFieldViewModel.swift
@@ -42,11 +42,11 @@ class ObservationLocationFieldViewModel: ObservableObject {
         }
     }
     @Published var observationMapItems: [ObservationMapItem] = []
-    @Published var selectedItem: Int = 0
+    @Published var currentItemIndex: Int = 0
 
     var currentItem: ObservationMapItem? {
-        if selectedItem < observationMapItems.count {
-            return observationMapItems[selectedItem]
+        if currentItemIndex < observationMapItems.count {
+            return observationMapItems[currentItemIndex]
         }
         return nil
     }

--- a/Mage/ObservationMapItemView.swift
+++ b/Mage/ObservationMapItemView.swift
@@ -11,6 +11,7 @@ import MaterialViews
 import SwiftUI
 import MAGEStyle
 import MapFramework
+import GeoPackage
 
 struct ObservationMapItemView: View {
 
@@ -31,13 +32,24 @@ struct ObservationMapItemView: View {
         .onChange(of: observationUri) { observationUri in
             viewModel.observationUri = observationUri
         }
-        .onChange(of: viewModel.selectedItem) { selectedItem in
-            mapState.coordinateCenter = viewModel.currentItem?.coordinate
+        .onChange(of: viewModel.currentItemIndex) { _ in
+            updateMap()
+        }
+        .onChange(of: viewModel.observationMapItems) { _ in
+            updateMap()
         }
         .onAppear {
             viewModel.observationUri = observationUri
+            updateMap()
             mixins.addMixin(OnlineLayerMapMixin())
             mixins.addMixin(ObservationMap(mapFeatureRepository: ObservationMapFeatureRepository(observationUri: observationUri)))
+        }
+    }
+    
+    func updateMap() {
+        if let currentItem = viewModel.currentItem {
+            let region = currentItem.boundingRegion()
+            mapState.centerRegion = region
         }
     }
 
@@ -62,9 +74,7 @@ struct ObservationMapItemView: View {
             } else if viewModel.observationMapItems.count > 1 {
                 Button(
                     action: {
-                        withAnimation {
-                            viewModel.selectedItem = max(0, viewModel.selectedItem  - 1)
-                        }
+                        viewModel.currentItemIndex = max(0, viewModel.currentItemIndex  - 1)
                     },
                     label: {
                         Label(
@@ -72,7 +82,7 @@ struct ObservationMapItemView: View {
                             icon: {
                                 Image(systemName: "chevron.left")
                                     .renderingMode(.template)
-                                    .foregroundColor(viewModel.selectedItem  != 0
+                                    .foregroundColor(viewModel.currentItemIndex  != 0
                                                      ? Color.primaryColorVariant : Color.disabledColor
                                     )
                             })
@@ -92,9 +102,7 @@ struct ObservationMapItemView: View {
                 }
                 Button(
                     action: {
-                        withAnimation {
-                            viewModel.selectedItem = min(viewModel.observationMapItems.count - 1, viewModel.selectedItem + 1)
-                        }
+                        viewModel.currentItemIndex = min(viewModel.observationMapItems.count - 1, viewModel.currentItemIndex + 1)
                     },
                     label: {
                         Label(
@@ -102,7 +110,7 @@ struct ObservationMapItemView: View {
                             icon: {
                                 Image(systemName: "chevron.right")
                                     .renderingMode(.template)
-                                    .foregroundColor(viewModel.observationMapItems.count - 1 != viewModel.selectedItem
+                                    .foregroundColor(viewModel.observationMapItems.count - 1 != viewModel.currentItemIndex
                                                      ? Color.primaryColorVariant : Color.disabledColor)
                             })
                     }

--- a/Mage/ObservationMapItemViewModel.swift
+++ b/Mage/ObservationMapItemViewModel.swift
@@ -25,11 +25,11 @@ class ObservationMapItemViewModel: ObservableObject {
         }
     }
     @Published var observationMapItems: [ObservationMapItem] = []
-    @Published var selectedItem: Int = 0
+    @Published var currentItemIndex: Int = 0
 
     var currentItem: ObservationMapItem? {
-        if selectedItem < observationMapItems.count {
-            return observationMapItems[selectedItem]
+        if currentItemIndex < observationMapItems.count {
+            return observationMapItems[currentItemIndex]
         }
         return nil
     }

--- a/Mage/preferences.plist
+++ b/Mage/preferences.plist
@@ -30,5 +30,7 @@
 	<integer>500</integer>
 	<key>geopackage_feature_tiles_min_zoom_offset</key>
 	<integer>0</integer>
+	<key>pointCoordinateSpan</key>
+	<integer>1000</integer>
 </dict>
 </plist>

--- a/Packages/MapFramework/Sources/MapFramework/MapCoordinator.swift
+++ b/Packages/MapFramework/Sources/MapFramework/MapCoordinator.swift
@@ -17,11 +17,8 @@ public class MapCoordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDel
     var focusedAnnotation: DataSourceAnnotation?
     var focusMapOnItemSink: AnyCancellable?
 
-    var setCenter: CLLocationCoordinate2D?
+    var centerCoordinate: CLLocationCoordinate2D?
     var trackingModeSet: MKUserTrackingMode?
-
-    var forceCenterDate: Date?
-    var centerDate: Date?
 
     var currentRegion: MKCoordinateRegion?
 
@@ -193,14 +190,17 @@ public class MapCoordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDel
 }
 
 extension MapCoordinator {
-    func setMapRegion(region: MKCoordinateRegion) {
+    
+    /// Sets the map to the current region
+    func setMapRegion(_ region: MKCoordinateRegion) {
         currentRegion = region
-        self.mapView?.setRegion(region, animated: true)
+        mapView?.setRegion(region, animated: true)
     }
 
-    func setCoordinateCenter(coordinate: CLLocationCoordinate2D) {
-        setCenter = coordinate
-        self.mapView?.setCenter(coordinate, animated: true)
+    /// Sets the map to a specific coordinate
+    func setCenterCoordinate(_ coordinate: CLLocationCoordinate2D) {
+        centerCoordinate = coordinate
+        mapView?.setCenter(coordinate, animated: true)
     }
 
     func addAnnotation(annotation: MKAnnotation) {

--- a/Packages/MapFramework/Sources/MapFramework/MapRepresentable.swift
+++ b/Packages/MapFramework/Sources/MapFramework/MapRepresentable.swift
@@ -57,9 +57,7 @@ public struct MapRepresentable: UIViewRepresentable, MapProtocol {
         mapView.accessibilityLabel = name
 
         context.coordinator.mapView = mapView
-        if let region = context.coordinator.currentRegion {
-            context.coordinator.setMapRegion(region: region)
-        }
+        setMapLocation(context: context)
 
         mapView.register(
             EnlargedAnnotationView.self,
@@ -75,21 +73,11 @@ public struct MapRepresentable: UIViewRepresentable, MapProtocol {
     }
 
     func setMapLocation(context: Context) {
-        if let center = mapState.center,
-           center.center.latitude != context.coordinator.setCenter?.latitude,
-           center.center.longitude != context.coordinator.setCenter?.longitude {
-            context.coordinator.setMapRegion(region: center)
-            context.coordinator.setCenter = center.center
-        }
-
-        if let center = mapState.forceCenter, context.coordinator.forceCenterDate != mapState.forceCenterDate {
-            context.coordinator.setMapRegion(region: center)
-            context.coordinator.forceCenterDate = mapState.forceCenterDate
-        }
-
-        if let center = mapState.coordinateCenter, context.coordinator.forceCenterDate != mapState.forceCenterDate {
-            context.coordinator.setCoordinateCenter(coordinate: center)
-            context.coordinator.setCenter = center
+        if let region = mapState.centerRegion, // Default to region to have proper zoom on the observation point/geometry
+           region.center.latitude != context.coordinator.centerCoordinate?.latitude,
+           region.center.longitude != context.coordinator.centerCoordinate?.longitude {
+            context.coordinator.setMapRegion(region)
+            context.coordinator.centerCoordinate = region.center
         }
     }
 

--- a/Packages/MapFramework/Sources/MapFramework/MapState.swift
+++ b/Packages/MapFramework/Sources/MapFramework/MapState.swift
@@ -49,22 +49,5 @@ public class MapState: ObservableObject, Hashable {
     @Published public var userTrackingMode: Int = Int(MKUserTrackingMode.none.rawValue)
     @Published public var mixinStates: [String: Any] = [:]
 
-    public var centerDate: Date?
-    @Published public var center: MKCoordinateRegion? {
-        didSet {
-            centerDate = Date()
-        }
-    }
-    @Published public var forceCenter: MKCoordinateRegion? {
-        didSet {
-            forceCenterDate = Date()
-        }
-    }
-    public var forceCenterDate: Date?
-
-    @Published public var coordinateCenter: CLLocationCoordinate2D? {
-        didSet {
-            forceCenterDate = Date()
-        }
-    }
+    @Published public var centerRegion: MKCoordinateRegion?
 }


### PR DESCRIPTION
Fixes the maps so they show actual geometry and points on the Observation View and the Edit Observation View.

* Updates the map locations to use regions for displaying locations (this gives us control of the latitude/longitude span)
* Unifies all logic to use 1,000 meters as a default bounds for a point.
* Polygons and lines are padded by 10% on all sides

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1718

<img width="250" alt="Fixed geometry" src="https://github.com/user-attachments/assets/ea9ab059-3788-455e-a8e9-d019052a7280" />


https://github.com/user-attachments/assets/a034d1c9-758e-482a-a7d7-083ac3a21e1d

