### PR TITLE
MAGE-1734: Fixes Forms to show only valid form fields (maps + text)

### DIFF
--- a/Mage/CoreData/Observation.swift
+++ b/Mage/CoreData/Observation.swift
@@ -915,8 +915,8 @@ enum ObservationState: Int, CustomStringConvertible {
             return nil
         }
     }
-    
-    @available(*, deprecated, message: "Don't use this anymore")
+   
+    @available(*, deprecated, message: "Don't use this anymore") // FIXME: Can we migrate off this method?
     @objc public var primaryFieldText: String? {
         get {
             if let primaryField = primaryEventForm?.primaryMapField, let observationForms = self.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let primaryFieldName = primaryField[FieldKey.name.key] as? String, observationForms.count > 0 {
@@ -927,7 +927,7 @@ enum ObservationState: Int, CustomStringConvertible {
         }
     }
     
-    @available(*, deprecated, message: "Don't use this anymore")
+    @available(*, deprecated, message: "Don't use this anymore") // FIXME: Can we migrate off this method?
     @objc public var secondaryFieldText: String? {
         get {
             if let variantField = primaryEventForm?.secondaryMapField, let observationForms = self.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let variantFieldName = variantField[FieldKey.name.key] as? String, observationForms.count > 0 {
@@ -938,26 +938,17 @@ enum ObservationState: Int, CustomStringConvertible {
         }
     }
     
-    @available(*, deprecated, message: "Don't use this anymore")
-    @objc public var primaryFeedFieldText: String? {
-        get {
-            if let primaryFeedField = primaryEventForm?.primaryFeedField, let observationForms = self.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let primaryFeedFieldName = primaryFeedField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = primaryObservationForm?[primaryFeedFieldName]
-                return Observation.fieldValueText(value: value, field: primaryFeedField)
-            }
-            return nil;
+    /// Get the text for a form field. General purpose and returns `nil` if values are empty.
+    static func text(form: [AnyHashable: Any]?, fieldDefinition: [AnyHashable: Any]?) -> String? {
+        guard let form = form,
+              let field = fieldDefinition,
+              let fieldName = field[FieldKey.name.key] as? String,
+              let value = form[fieldName] else {
+            return nil
         }
-    }
-    
-    @available(*, deprecated, message: "Don't use this anymore")
-    @objc public var secondaryFeedFieldText: String? {
-        get {
-            if let secondaryFeedField = primaryEventForm?.secondaryFeedField, let observationForms = self.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let secondaryFeedFieldName = secondaryFeedField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[secondaryFeedFieldName]
-                return Observation.fieldValueText(value: value, field: secondaryFeedField)
-            }
-            return nil;
-        }
+        
+        let text = Observation.fieldValueText(value: value, field: field)
+        return text.isEmpty ? nil : text
     }
     
     public func getAccuracy() -> Double? {
@@ -1070,20 +1061,10 @@ enum ObservationState: Int, CustomStringConvertible {
                     in: context
                 )
                 
-                if let form = primaryObservationForm,
-                   let eventForm = eventForm,
-                   let primaryField = eventForm.primaryMapField,
-                   let primaryFieldName = primaryField[FieldKey.name.key] as? String
-                {
+                if let form = primaryObservationForm {
                     observationLocation.observationFormId = form[FormKey.id.key] as? String
-                    let primaryValue = form[primaryFieldName]
-                    observationLocation.primaryFieldText = Observation.fieldValueText(value: primaryValue, field: primaryField)
-                    if let secondaryField = eventForm.secondaryMapField,
-                       let secondaryFieldName = secondaryField[FieldKey.name.key] as? String
-                    {
-                        let secondaryValue = form[secondaryFieldName]
-                        observationLocation.secondaryFieldText = Observation.fieldValueText(value: secondaryValue, field: secondaryField)
-                    }
+                    observationLocation.primaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.primaryMapField)
+                    observationLocation.secondaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.secondaryMapField)
                 }
                 observationLocation.geometryData = SFGeometryUtils.encode(geometry)
                 if let centroid = geometry.centroid() {
@@ -1138,19 +1119,8 @@ enum ObservationState: Int, CustomStringConvertible {
                                     in: context
                                 )
                                 
-                                if let eventForm = eventForm,
-                                   let primaryField = eventForm.primaryMapField,
-                                   let primaryFieldName = primaryField[FieldKey.name.key] as? String
-                                {
-                                    let primaryValue = form[primaryFieldName]
-                                    observationLocation.primaryFieldText = Observation.fieldValueText(value: primaryValue, field: primaryField)
-                                    if let secondaryField = eventForm.secondaryMapField,
-                                       let secondaryFieldName = secondaryField[FieldKey.name.key] as? String
-                                    {
-                                        let secondaryValue = form[secondaryFieldName]
-                                        observationLocation.secondaryFieldText = Observation.fieldValueText(value: secondaryValue, field: secondaryField)
-                                    }
-                                }
+                                observationLocation.primaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.primaryMapField)
+                                observationLocation.secondaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.secondaryMapField)
                                 
                                 observationLocation.geometryData = SFGeometryUtils.encode(geometry)
                                 if let centroid = geometry.centroid() {

--- a/Mage/ObservationFormViewSwiftUI.swift
+++ b/Mage/ObservationFormViewSwiftUI.swift
@@ -17,7 +17,6 @@ struct ObservationFormViewSwiftUI: View {
     var router: MageRouter
     
     var viewModel: ObservationFormViewModel
-//    var selectedAttachment: (_ attachmentUri: URL) -> Void
     var selectedUnsentAttachment: (_ localPath: String, _ contentType: String) -> Void
     
     var body: some View {
@@ -55,49 +54,53 @@ struct ObservationFormViewSwiftUI: View {
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         ForEach(viewModel.formFields) { field in
-                            if field.type != FieldType.attachment.key {
-                                Text(field.title)
-                                    .secondaryText()
-                            }
-                            switch (field.type) {
-                            case FieldType.password.key:
-                                Text(viewModel.fieldStringValue(fieldName: field.name) ?? "")
-                                    .privacySensitive()
-                                    .padding(.bottom, 8)
-                            case FieldType.checkbox.key:
-                                if (viewModel.fieldStringValue(fieldName: field.name) ?? "false") == "true" {
-                                    Image(systemName:"checkmark.square.fill")
-                                        .foregroundStyle(Color.primaryColorVariant)
-                                        .padding(.bottom, 8)
-                                } else {
-                                    Image(systemName:"square")
-                                        .foregroundStyle(Color.primaryColorVariant)
-                                        .padding(.bottom, 8)
+                            if viewModel.shouldDisplay(field: field) {
+                                let fieldValue = viewModel.fieldStringValue(fieldName: field.name) ?? ""
+                                
+                                if field.type != FieldType.attachment.key {
+                                    Text(field.title)
+                                        .secondaryText()
                                 }
-                            case FieldType.attachment.key:
-                                AttachmentFieldViewSwiftUI(
-                                    viewModel: AttachmentFieldViewModel(
-                                        observationUri: viewModel.form.observationId,
-                                        observationFormId: viewModel.form.id,
-                                        fieldName: field.name,
-                                        fieldTitle: field.title
-                                    ),
-//                                    selectedAttachment: selectedAttachment,
-                                    selectedUnsentAttachment: selectedUnsentAttachment
-                                )
-                                .padding(.bottom, 8)
-                            case FieldType.geometry.key:
-                                if let observationUri = viewModel.form.observationId {
-                                    ObservationLocationFieldView(
-                                        observationUri: observationUri,
-                                        observationFormId: viewModel.form.id,
-                                        fieldName: field.name
+                                
+                                switch (field.type) {
+                                case FieldType.password.key:
+                                    Text(fieldValue)
+                                        .privacySensitive()
+                                        .padding(.bottom, 8)
+                                case FieldType.checkbox.key:
+                                    if fieldValue == "true" {
+                                        Image(systemName:"checkmark.square.fill")
+                                            .foregroundStyle(Color.primaryColorVariant)
+                                            .padding(.bottom, 8)
+                                    } else {
+                                        Image(systemName:"square")
+                                            .foregroundStyle(Color.primaryColorVariant)
+                                            .padding(.bottom, 8)
+                                    }
+                                case FieldType.attachment.key:
+                                    AttachmentFieldViewSwiftUI(
+                                        viewModel: AttachmentFieldViewModel(
+                                            observationUri: viewModel.form.observationId,
+                                            observationFormId: viewModel.form.id,
+                                            fieldName: field.name,
+                                            fieldTitle: field.title
+                                        ),
+                                        selectedUnsentAttachment: selectedUnsentAttachment
                                     )
                                     .padding(.bottom, 8)
+                                case FieldType.geometry.key:
+                                    if let observationUri = viewModel.form.observationId { // This part is different from the file content
+                                        ObservationLocationFieldView(
+                                            observationUri: observationUri,
+                                            observationFormId: viewModel.form.id,
+                                            fieldName: field.name
+                                        )
+                                        .padding(.bottom, 8)
+                                    }
+                                default:
+                                    Text(fieldValue)
+                                        .padding(.bottom, 8)
                                 }
-                            default:
-                                Text(viewModel.fieldStringValue(fieldName: field.name) ?? "")
-                                    .padding(.bottom, 8)
                             }
                         }
                     }

--- a/Mage/ViewModel/Observation/ObservationFormViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationFormViewModel.swift
@@ -38,21 +38,11 @@ class ObservationFormViewModel: ObservableObject {
     }
     
     var primaryFieldText: String? {
-        if let field = eventForm?.primaryFeedField, let fieldName = field[FieldKey.name.key] as? String {
-            if let obsfield = form.form[fieldName] {
-                return Observation.fieldValueText(value: obsfield, field: field)
-            }
-        }
-        return nil
+        return Observation.text(form: form.form, fieldDefinition: eventForm?.primaryFeedField)
     }
     
     var secondaryFieldText: String? {
-        if let field = eventForm?.secondaryFeedField, let fieldName = field[FieldKey.name.key] as? String {
-            if let obsfield = form.form[fieldName] {
-                return Observation.fieldValueText(value: obsfield, field: field)
-            }
-        }
-        return nil
+        return Observation.text(form: form.form, fieldDefinition: eventForm?.secondaryFeedField)
     }
     
     lazy var formFields: [ObservationFormFieldModel] = {
@@ -69,6 +59,20 @@ class ObservationFormViewModel: ObservableObject {
             ObservationFormFieldModel(field: fieldDictionary)
         }
     }()
+    
+    func shouldDisplay(field: ObservationFormFieldModel) -> Bool {
+        guard let value = form.form[field.name] else { return false }
+        
+        if let value = value as? String {
+            return !value.isEmpty
+        }
+        
+        if let value = value as? [Any] {
+            return !value.isEmpty
+        }
+        
+        return true
+    }
     
     func fieldStringValue(fieldName: String) -> String? {
         let field = formFields.first { fieldModel in

--- a/Mage/ViewModel/Observation/ObservationSummaryViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationSummaryViewModel.swift
@@ -43,41 +43,37 @@ class ObservationSummaryViewModel: ObservableObject {
     
     public var primaryFieldText: String? {
         get {
-            if let primaryField = primaryEventForm?.primaryMapField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let primaryFieldName = primaryField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[primaryFieldName]
-                return Observation.fieldValueText(value: value, field: primaryField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.primaryMapField
+            )
         }
     }
 
     public var secondaryFieldText: String? {
         get {
-            if let variantField = primaryEventForm?.secondaryMapField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let variantFieldName = variantField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[variantFieldName]
-                return Observation.fieldValueText(value: value, field: variantField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.secondaryMapField
+            )
         }
     }
 
     public var primaryFeedFieldText: String? {
         get {
-            if let primaryFeedField = primaryEventForm?.primaryFeedField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let primaryFeedFieldName = primaryFeedField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = primaryObservationForm?[primaryFeedFieldName]
-                return Observation.fieldValueText(value: value, field: primaryFeedField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.primaryFeedField
+            )
         }
     }
 
     public var secondaryFeedFieldText: String? {
         get {
-            if let secondaryFeedField = primaryEventForm?.secondaryFeedField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let secondaryFeedFieldName = secondaryFeedField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[secondaryFeedFieldName]
-                return Observation.fieldValueText(value: value, field: secondaryFeedField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.secondaryFeedField
+            )
         }
     }
 }

--- a/Mage/ViewModel/Observation/ObservationViewViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationViewViewModel.swift
@@ -209,41 +209,37 @@ class ObservationViewViewModel: NSObject, ObservableObject {
     
     public var primaryFieldText: String? {
         get {
-            if let primaryField = primaryEventForm?.primaryMapField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let primaryFieldName = primaryField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[primaryFieldName]
-                return Observation.fieldValueText(value: value, field: primaryField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.primaryMapField
+            )
         }
     }
 
     public var secondaryFieldText: String? {
         get {
-            if let variantField = primaryEventForm?.secondaryMapField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let variantFieldName = variantField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[variantFieldName]
-                return Observation.fieldValueText(value: value, field: variantField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.secondaryMapField
+            )
         }
     }
 
     public var primaryFeedFieldText: String? {
         get {
-            if let primaryFeedField = primaryEventForm?.primaryFeedField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let primaryFeedFieldName = primaryFeedField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = primaryObservationForm?[primaryFeedFieldName]
-                return Observation.fieldValueText(value: value, field: primaryFeedField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.primaryFeedField
+            )
         }
     }
 
     public var secondaryFeedFieldText: String? {
         get {
-            if let secondaryFeedField = primaryEventForm?.secondaryFeedField, let observationForms = self.observationModel?.properties?[ObservationKey.forms.key] as? [[AnyHashable : Any]], let secondaryFeedFieldName = secondaryFeedField[FieldKey.name.key] as? String, observationForms.count > 0 {
-                let value = self.primaryObservationForm?[secondaryFeedFieldName]
-                return Observation.fieldValueText(value: value, field: secondaryFeedField)
-            }
-            return nil;
+            return Observation.text(
+                form: primaryObservationForm,
+                fieldDefinition: primaryEventForm?.secondaryFeedField
+            )
         }
     }
 }


### PR DESCRIPTION
MAGE-1734: Fixes Forms to show only valid form fields (maps + text)

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1734

* Prevents blank maps from appearing when locations are not set
* Created reusable helpers for primaryField and secondaryField for mapField and feedField.
* Removed dead and deprecated code

https://github.com/user-attachments/assets/7f6815cb-2efa-4f6d-9e53-d0cb6f87df44

