### PR TITLE
MAGE-1733: Fixes the Blank Map and Observation Summary Views

### DIFF
--- a/Mage/BottomSheets/MageBottomSheet.swift
+++ b/Mage/BottomSheets/MageBottomSheet.swift
@@ -77,7 +77,6 @@ struct MageBottomSheet: View {
             )
             .animation(.default, value: self.viewModel.selectedItem)
             
-            Spacer()
         }
         .background(Color.surfaceColor)
         

--- a/Mage/CoreData/Observation.swift
+++ b/Mage/CoreData/Observation.swift
@@ -1063,8 +1063,8 @@ enum ObservationState: Int, CustomStringConvertible {
                 
                 if let form = primaryObservationForm {
                     observationLocation.observationFormId = form[FormKey.id.key] as? String
-                    observationLocation.primaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.primaryMapField)
-                    observationLocation.secondaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.secondaryMapField)
+                    observationLocation.primaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.primaryFeedField)
+                    observationLocation.secondaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.secondaryFeedField)
                 }
                 observationLocation.geometryData = SFGeometryUtils.encode(geometry)
                 if let centroid = geometry.centroid() {
@@ -1119,9 +1119,8 @@ enum ObservationState: Int, CustomStringConvertible {
                                     in: context
                                 )
                                 
-                                observationLocation.primaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.primaryMapField)
-                                observationLocation.secondaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.secondaryMapField)
-                                
+                                observationLocation.primaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.primaryFeedField)
+                                observationLocation.secondaryFieldText = Observation.text(form: form, fieldDefinition: eventForm?.secondaryFeedField)
                                 observationLocation.geometryData = SFGeometryUtils.encode(geometry)
                                 if let centroid = geometry.centroid() {
                                     observationLocation.latitude = centroid.y.doubleValue

--- a/Mage/Mixins/BottomSheetEnabled.swift
+++ b/Mage/Mixins/BottomSheetEnabled.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2021 National Geospatial Intelligence Agency. All rights reserved.
 //
 
+import Combine
 import Foundation
 import MapFramework
-import Combine
+import SwiftUI
 
 protocol BottomSheetEnabled {
     var mapView: MKMapView? { get set }
@@ -74,8 +75,17 @@ class BottomSheetMixin: NSObject, MapMixin {
         let mageBottomSheet = SwiftUIViewController(swiftUIView: MageBottomSheet())
         mageBottomSheet.modalPresentationStyle = .pageSheet
         if let sheet = mageBottomSheet.sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
+            sheet.detents = [
+                .medium(),
+                .large(),
+                .custom(identifier: .init("contentFit")) { context in
+                    // Read the calculated height from the hosting controller
+                    let height = mageBottomSheet.preferredContentSize.height
+                    return height > 0 ? height : 220
+                },
+            ]
         }
+        
         self.bottomSheetEnabled.navigationController?.present(mageBottomSheet, animated: true, completion: nil)
         
         self.mageBottomSheet = mageBottomSheet

--- a/Mage/Model/Observation/ObservationMapItem.swift
+++ b/Mage/Model/Observation/ObservationMapItem.swift
@@ -132,7 +132,7 @@ extension ObservationMapItem {
         self.minLongitude = observation.minLongitude
         self.primaryFieldText = observation.primaryFieldText
         self.secondaryFieldText = observation.secondaryFieldText
-        // TODO: should we store the primary and secondary feed field text too?
+        
         if let observation = observation.observation {
             let style = ObservationShapeStyleParser.style(
                 observation: observation,

--- a/Mage/ObservationHeaderView.swift
+++ b/Mage/ObservationHeaderView.swift
@@ -41,9 +41,9 @@ struct ObservationHeaderViewSwiftUI: View {
                 ObservationLocationSummary(
                     timestamp: viewModel.observationModel?.timestamp,
                     user: viewModel.user?.name,
-                    primaryFieldText: viewModel.primaryFieldText,
-                    secondaryFieldText: viewModel.secondaryFieldText,
-                    iconPath: nil, 
+                    primaryFieldText: viewModel.primaryFeedFieldText,
+                    secondaryFieldText: viewModel.secondaryFeedFieldText,
+                    iconPath: nil,
                     error: viewModel.observationModel?.error ?? false,
                     syncing: viewModel.observationModel?.syncing ?? false
                 )

--- a/Mage/UI/MageHostingController.swift
+++ b/Mage/UI/MageHostingController.swift
@@ -14,6 +14,15 @@ class MageHostingController<Content>: UIHostingController<Content> where Content
         super.viewDidLayoutSubviews()
         self.view.invalidateIntrinsicContentSize()
     }
+    
+    override init(rootView: Content) {
+        super.init(rootView: rootView)
+        sizingOptions = .preferredContentSize
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("Not implemented")
+    }
 }
 
 class SwiftUIViewController: UIViewController {


### PR DESCRIPTION
Fixes the blank titles on the map point, feed, or Geopackage item details.

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1733

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-02-02 at 21 53 40" src="https://github.com/user-attachments/assets/4f64b451-906a-4ab1-ac9c-f38df4f0fbd7" />

* The admin for the event can choose which text fields are used as the Primary and Secondary labels on the Event "Feed" settings.

<img width="500" alt="Screenshot 2026-02-02 at 9 52 02 PM" src="https://github.com/user-attachments/assets/1b7ee1a4-5645-4587-a12e-f25f111a4514" />

## After (Feature branch vs. App Store (4.2.0)

https://github.com/user-attachments/assets/beec9cda-74a8-4047-9a7a-6709f7c1de7b

## Before
* Previously the map view was blank, and the observation summary was blank.
<img width="568" height="1084" alt="Screenshot_2025-12-09_at_2 59 31_PM" src="https://github.com/user-attachments/assets/7b24b87d-9baa-4178-ab3e-b6a0c434c89f" />
