### PR TITLE
MAGE-1769 Remove Unwanted Space on Observation Summary

### DIFF
--- a/Mage/UI/ObservationLocation/ObservationLocationSummary.swift
+++ b/Mage/UI/ObservationLocation/ObservationLocationSummary.swift
@@ -68,7 +68,6 @@ struct ObservationLocationSummary: View {
                         Text(secondaryFieldText)
                             .secondaryText()
                     }
-                    Spacer()
                 }
                 Spacer()
                 if let iconPath = iconPath {


### PR DESCRIPTION
Fixes the extra space.

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1769

<img width="300" alt="2025-2-10 Fixed padding" src="https://github.com/user-attachments/assets/ab772ba4-5d6f-4e50-a598-406dfb49b894" />
<img width="300" alt="2026-2-10 Extra Gap in Header View Spacing" src="https://github.com/user-attachments/assets/cd6104ea-452a-4c79-9637-ea6875c8ff93" />
