### PR TITLE
1768 - user observations header section date

### DIFF
--- a/Mage/UI/User/UserObservationList.swift
+++ b/Mage/UI/User/UserObservationList.swift
@@ -137,8 +137,15 @@ struct UserObservationRow: View {
                 // Fallback view if objectID cannot be resolved
                 Text("Unable to load observation")
             }
-        case .sectionHeader(_):
-            EmptyView()
+        case .sectionHeader(let header):
+            HStack {
+                Text(header)
+                    .padding()
+                    .font(.overline)
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.backgroundColor)
+                Spacer()
+            }
         }
     }
 }


### PR DESCRIPTION
- fixed header/sections not showing on User/Profile tab

- NEW <-> OLD
<img width="400" alt="user_new_old_dark" src="https://github.com/user-attachments/assets/24ebdb23-b7df-49cc-97f8-296d4abe98f5" />
<img width="400" alt="user_new_old_light" src="https://github.com/user-attachments/assets/72972e3b-65db-48f2-af61-0e51bbba966b" />
