### PR TITLE
Fix - cursor color not being readable depending on color mode

### DIFF
--- a/Mage/DateView.swift
+++ b/Mage/DateView.swift
@@ -75,6 +75,7 @@ class DateView : BaseFieldView {
         super.applyTheme(withScheme: scheme);
         textField.applyTheme(withScheme: scheme);
         textField.trailingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6);
+        textField.tintColor = scheme.colorScheme.onSurfaceColor;
     }
     
     required init(coder aDecoder: NSCoder) {

--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -91,6 +91,7 @@ class NumberFieldView : BaseFieldView {
         super.applyTheme(withScheme: scheme);
         textField.applyTheme(withScheme: scheme);
         textField.trailingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6);
+        textField.tintColor = scheme.colorScheme.onSurfaceColor;
     }
     
     func setupInputView() {

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -117,9 +117,11 @@ class TextFieldView : BaseFieldView {
         if (multiline) {
             multilineTextField.applyTheme(withScheme: scheme);
             multilineTextField.trailingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6);
+            multilineTextField.textView.tintColor = scheme.colorScheme.onSurfaceColor;
         } else {
             textField.applyTheme(withScheme: scheme);
             textField.trailingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6);
+            textField.tintColor = scheme.colorScheme.onSurfaceColor;
         }
     }
     


### PR DESCRIPTION
BEFORE

<img height="440" alt="before-light" src="https://github.com/user-attachments/assets/addc47dc-f819-4025-ab57-782b853d99db" />
<img height="440" alt="before-dark" src="https://github.com/user-attachments/assets/b929e9fe-7b53-49d0-b5f1-4fbceaff4647" />

AFTER

<img height="440" alt="after-light" src="https://github.com/user-attachments/assets/42d46974-e17b-4c09-ae6c-939fbc15383f" />
<img height="440" alt="after-dark" src="https://github.com/user-attachments/assets/a8dc5b28-1420-4be0-abb0-edb33e43cc0f" />
