### PR TITLE
Fix - Observation form attachments not showing

### DIFF
--- a/Mage/ViewModel/Observation/ObservationFormViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationFormViewModel.swift
@@ -61,6 +61,7 @@ class ObservationFormViewModel: ObservableObject {
     }()
     
     func shouldDisplay(field: ObservationFormFieldModel) -> Bool {
+        if field.type == FieldType.attachment.key { return true }
         guard let value = form.form[field.name] else { return false }
         
         if let value = value as? String {


### PR DESCRIPTION
- if type is attachment always display

BEFORE <--> AFTER:
<img width="225" alt="After" src="https://github.com/user-attachments/assets/2e2d8698-b685-478b-8c21-db2c9799704e" /> <img width="225" alt="Before" src="https://github.com/user-attachments/assets/39d46916-35f5-4aae-836d-de1c1a281ced" />
