### PR TITLE
Mage-1822: Enable Core Data debugging to track down crashes

### DIFF
--- a/MAGE.xcodeproj/xcshareddata/xcschemes/MAGE.xcscheme
+++ b/MAGE.xcodeproj/xcshareddata/xcschemes/MAGE.xcscheme
@@ -99,6 +99,12 @@
             ReferencedContainer = "container:MAGE.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = " -com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"


### PR DESCRIPTION
Mage-1822: Enable Core Data debugging to track down crashes

NOTE: We must disable before we cut the next beta release, but this helps track down crashes as we work.

` -com.apple.CoreData.ConcurrencyDebug 1`

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1822