### PR TITLE
MAGE-1827: Fixes Blank Fields in Server Created Observations

### DIFF
--- a/Mage/ViewModel/Observation/ObservationFormViewModel.swift
+++ b/Mage/ViewModel/Observation/ObservationFormViewModel.swift
@@ -64,6 +64,10 @@ class ObservationFormViewModel: ObservableObject {
         if field.type == FieldType.attachment.key { return true }
         guard let value = form.form[field.name] else { return false }
         
+        if value is NSNull { // Ignore Null values (server created entries use null values)
+            return false
+        }
+        
         if let value = value as? String {
             return !value.isEmpty
         }


### PR DESCRIPTION
Fixes blank fields from server created observations. 

* Server observations (and potentially Android) create observations with `null` values for unset fields.
* Our new SwiftUI view's didn't respect the `null` fields.

We should not see any entries in the Multiple Locations form that is blank.

<img width="250" alt="Simulator Screenshot - iPhone 17 - 2026-03-10 at 15 11 22" src="https://github.com/user-attachments/assets/deebaad9-0a0a-4d98-b6f0-c89a28e33006" />
<img width="250" alt="Simulator Screenshot - iPhone 17 - 2026-03-10 at 15 11 18" src="https://github.com/user-attachments/assets/63d35abc-eab8-4405-b54d-aeb39d7dfffa" />


## Before

https://github.com/user-attachments/assets/f29f2126-3bc9-47d6-86ac-d2a675043443

## After

https://github.com/user-attachments/assets/64e7b4ab-0e8f-49a7-bb21-0eff4c43b090


