### PR TITLE
1829 - Observation important flag appears editable by non-admins

### DIFF
--- a/Mage/ObservationHeaderView.swift
+++ b/Mage/ObservationHeaderView.swift
@@ -85,6 +85,7 @@ struct ObservationHeaderViewSwiftUI: View {
                     }.padding()
                 }
                 ObservationViewActionBar(
+                    showImportant: viewModel.currentUserCanUpdateImportant,
                     isImportant: viewModel.isImportant,
                     importantAction: {
                         viewModel.settingImportant = !viewModel.settingImportant

--- a/Mage/UI/ObservationLocation/ObservationLocationBottomSheetActionBar.swift
+++ b/Mage/UI/ObservationLocation/ObservationLocationBottomSheetActionBar.swift
@@ -120,6 +120,7 @@ struct ObservationLocationBottomSheetActionBar: View {
 }
 
 struct ObservationViewActionBar: View {
+    var showImportant: Bool
     var isImportant: Bool
     var importantAction: () -> Void
     var favoriteCount: Int?
@@ -138,10 +139,12 @@ struct ObservationViewActionBar: View {
             
             Spacer()
             
-            ImportantButton(
-                importantAction: importantAction,
-                isImportant: isImportant
-            )
+            if showImportant {
+                ImportantButton(
+                    importantAction: importantAction,
+                    isImportant: isImportant
+                )
+            }
             
             FavoriteButton(
                 currentUserFavorite: currentUserFavorite,


### PR DESCRIPTION
# 1829 - Observation important flag appears editable by non-admins
- only show important flag when user has admin role

- ADMIN role <---> USER role
<img width="240" alt="admin role" src="https://github.com/user-attachments/assets/de1e7221-d150-40ab-b30d-971505a78eeb" /> <img width="240" alt="user role" src="https://github.com/user-attachments/assets/ad2f5e3b-aff3-4e44-a800-56f5208476ca" />
