### PR TITLE
MAGE-1831: Fixes Form Keyboard Interactions and Scroll Behaviors

### DIFF
--- a/MAGE.xcodeproj/project.pbxproj
+++ b/MAGE.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		BDB16FA82DF7715400FDD03B /* SimpleFeaturesWKT in Frameworks */ = {isa = PBXBuildFile; productRef = BDB16FA72DF7715400FDD03B /* SimpleFeaturesWKT */; };
 		BDB16FAB2DF7717700FDD03B /* SimpleFeaturesProjections in Frameworks */ = {isa = PBXBuildFile; productRef = BDB16FAA2DF7717700FDD03B /* SimpleFeaturesProjections */; };
 		BDB16FAE2DF7719600FDD03B /* SimpleFeaturesGeoJSON in Frameworks */ = {isa = PBXBuildFile; productRef = BDB16FAD2DF7719600FDD03B /* SimpleFeaturesGeoJSON */; };
+		BDCD344B2F64A0C3008B1E4B /* ObservationValidationScrollTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCD344A2F64A0C3008B1E4B /* ObservationValidationScrollTarget.swift */; };
 		BDF39E422F59CE0500EDEE41 /* StaticLayerToggleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF39E412F59CE0500EDEE41 /* StaticLayerToggleTableViewCell.swift */; };
 		BFC94C4360074DCC5E09B8EA /* libPods-MAGE.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B61E70D96990B16652014926 /* libPods-MAGE.a */; };
 		D258D7802E253A4900A44AC4 /* SettingsLocalDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D258D77F2E253A4900A44AC4 /* SettingsLocalDataSource.swift */; };
@@ -762,6 +763,7 @@
 		F7CE22BC2540B01700D710DE /* ObservationEditCardCollectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CE22BB2540B01700D710DE /* ObservationEditCardCollectionViewControllerTests.swift */; };
 		F7CE22C02540DF2D00D710DE /* twoForms.json in Resources */ = {isa = PBXBuildFile; fileRef = F7CE22BF2540DF2D00D710DE /* twoForms.json */; };
 		F7CE22C62540DF7600D710DE /* zeroForms.json in Resources */ = {isa = PBXBuildFile; fileRef = F7CE22C52540DF7600D710DE /* zeroForms.json */; };
+		F7CE22D12540B11800D710DE /* ObservationValidationScrollLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CE22D02540B11800D710DE /* ObservationValidationScrollLayoutTests.swift */; };
 		F7CE2300254368B000D710DE /* allTheThings.json in Resources */ = {isa = PBXBuildFile; fileRef = F7CE22FF254368B000D710DE /* allTheThings.json */; };
 		F7CE2304254369BD00D710DE /* checkboxForm.json in Resources */ = {isa = PBXBuildFile; fileRef = F7CE2303254369BD00D710DE /* checkboxForm.json */; };
 		F7CE230A2544676800D710DE /* AttachmentFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CE23092544676800D710DE /* AttachmentFieldView.swift */; };
@@ -1170,6 +1172,7 @@
 		B61E70D96990B16652014926 /* libPods-MAGE.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MAGE.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD66678D2D82152100D9BBA0 /* MAGE.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = MAGE.xctestplan; sourceTree = "<group>"; };
 		BDAA14DC2F509C5C0049F657 /* OfflineMapTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMapTableViewControllerTests.swift; sourceTree = "<group>"; };
+		BDCD344A2F64A0C3008B1E4B /* ObservationValidationScrollTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationValidationScrollTarget.swift; sourceTree = "<group>"; };
 		BDF39E412F59CE0500EDEE41 /* StaticLayerToggleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLayerToggleTableViewCell.swift; sourceTree = "<group>"; };
 		D258D77F2E253A4900A44AC4 /* SettingsLocalDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLocalDataSource.swift; sourceTree = "<group>"; };
 		D258D7842E253B1300A44AC4 /* SettingsLocalDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLocalDataSourceTests.swift; sourceTree = "<group>"; };
@@ -1806,6 +1809,7 @@
 		F7CE22BB2540B01700D710DE /* ObservationEditCardCollectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationEditCardCollectionViewControllerTests.swift; sourceTree = "<group>"; };
 		F7CE22BF2540DF2D00D710DE /* twoForms.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = twoForms.json; sourceTree = "<group>"; };
 		F7CE22C52540DF7600D710DE /* zeroForms.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zeroForms.json; sourceTree = "<group>"; };
+		F7CE22D02540B11800D710DE /* ObservationValidationScrollLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationValidationScrollLayoutTests.swift; sourceTree = "<group>"; };
 		F7CE22FF254368B000D710DE /* allTheThings.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = allTheThings.json; sourceTree = "<group>"; };
 		F7CE2303254369BD00D710DE /* checkboxForm.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = checkboxForm.json; sourceTree = "<group>"; };
 		F7CE23092544676800D710DE /* AttachmentFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentFieldView.swift; sourceTree = "<group>"; };
@@ -3064,6 +3068,7 @@
 				F7B57729245C97D400879C9C /* ObservationEditCardCollectionViewController.swift */,
 				F7E2DF1625768CD100CD2ABA /* ObservationEditCoordinator.swift */,
 				F7813A8024621237003666ED /* ObservationFormView.swift */,
+				BDCD344A2F64A0C3008B1E4B /* ObservationValidationScrollTarget.swift */,
 				2FFF8E531CFF7B06002FD563 /* SelectEditViewController.h */,
 				2FFF8E541CFF7B06002FD563 /* SelectEditViewController.m */,
 			);
@@ -3830,6 +3835,7 @@
 				F7CE22BB2540B01700D710DE /* ObservationEditCardCollectionViewControllerTests.swift */,
 				F7E2DF0A2575A13200CD2ABA /* ObservationEditCoordinatorTests.swift */,
 				F7F9121C247EC00500C068B6 /* ObservationFormViewTests.swift */,
+				F7CE22D02540B11800D710DE /* ObservationValidationScrollLayoutTests.swift */,
 				8423B1122E4A5D2B0069C1CD /* AttachmentImageLoadingTests.swift */,
 			);
 			path = Edit;
@@ -5100,6 +5106,7 @@
 				F776ACAE2BD1820A000FAFB4 /* ObservationLocationLocalDataSource.swift in Sources */,
 				2F7D5D8C26025A9800886844 /* SignUpViewController_Server5.m in Sources */,
 				F7C5C8D51F5F28BC002C78D3 /* MageAppCoordinator.m in Sources */,
+				BDCD344B2F64A0C3008B1E4B /* ObservationValidationScrollTarget.swift in Sources */,
 				043FF1331C244D4A000CA07F /* GeoPackageFeatureTableCacheOverlay.swift in Sources */,
 				840D60822E4BE55E005B0353 /* URL+AccessToken.swift in Sources */,
 				2F0323AE246366B800D2866B /* LocationAccuracy.m in Sources */,
@@ -5479,6 +5486,7 @@
 				F7F264392806FDF100758C5B /* EventChooserControllerTests.swift in Sources */,
 				F7F91222247F046500C068B6 /* DropdownFieldViewTests.swift in Sources */,
 				F7F9121E247EC10000C068B6 /* ObservationFormViewTests.swift in Sources */,
+				F7CE22D12540B11800D710DE /* ObservationValidationScrollLayoutTests.swift in Sources */,
 				F7C097B22C8756F8003FA115 /* UserRemoteDataSourceTests.swift in Sources */,
 				F76EB1E4247D83FD0089F3AC /* NumberFieldViewTests.swift in Sources */,
 				F70D19E12742C5F3006E12F8 /* FormTests.swift in Sources */,

--- a/Mage/BaseFieldView.swift
+++ b/Mage/BaseFieldView.swift
@@ -155,8 +155,13 @@ class BaseFieldView : UIView {
         tapView.addGestureRecognizer(tapGesture)
         return tapView;
     }
+
+    func dismissActiveEditing() {
+        window?.endEditing(true)
+    }
     
     @objc func handleTap() {
+        dismissActiveEditing()
         fieldSelectionCoordinator?.fieldSelected();
     }
 }

--- a/Mage/CheckboxFieldView.swift
+++ b/Mage/CheckboxFieldView.swift
@@ -108,6 +108,7 @@ class CheckboxFieldView : BaseFieldView {
     }
     
     @objc func switchValueChanged(theSwitch: UISwitch) {
+        dismissActiveEditing()
         delegate?.fieldValueChanged(field, value: theSwitch.isOn);
     }
     

--- a/Mage/CheckboxFieldView.swift
+++ b/Mage/CheckboxFieldView.swift
@@ -54,7 +54,7 @@ class CheckboxFieldView : BaseFieldView {
         label.font = scheme?.typographyScheme.body1;
         label.textColor = scheme?.colorScheme.onSurfaceColor;
         errorLabel.font = scheme?.typographyScheme.caption;
-        checkboxSwitch.onTintColor = scheme?.colorScheme.primaryColorVariant;
+        checkboxSwitch.onTintColor = UIColor(named: "layerToggleOn")
     }
     
     required init(coder aDecoder: NSCoder) {

--- a/Mage/CommonFieldsView.swift
+++ b/Mage/CommonFieldsView.swift
@@ -93,6 +93,16 @@ class CommonFieldsView: MDCCard {
         dateView.setValid(dateView.isValid(enforceRequired: enforceRequired));
         return valid;
     }
+
+    func firstInvalidFieldView(enforceRequired: Bool = false) -> UIView? {
+        if !dateView.isValid(enforceRequired: enforceRequired) {
+            return dateView
+        }
+        if !geometryView.isValid(enforceRequired: enforceRequired) {
+            return geometryView
+        }
+        return nil
+    }
     
     func setDateValue() {
         if let observationProperties: [String : Any] = observation?.properties as? [String : Any] {

--- a/Mage/ExpandingTextEditor.swift
+++ b/Mage/ExpandingTextEditor.swift
@@ -20,7 +20,8 @@ struct ExpandingTextEditor: View {
     @State var text: String
     @State var workingText: String
     @State private var showSheet = false
-    
+    @FocusState private var isFocused: Bool
+
     private var isRequiredField: Bool {
         return (field[FieldKey.required.key] as? Bool) == true
     }
@@ -57,6 +58,7 @@ struct ExpandingTextEditor: View {
                     .scrollContentBackground(.hidden) // this hides the special background color that only lives behind the text inside this area
                     .frame(minHeight: 55, maxHeight: 650)
                     .padding([.bottom], 12)
+                    .focused($isFocused)
             }
             .background(Color(.onSurface).opacity(0.12)) // derived from MAGEScheme
             .onChange(of: text) { newValue in
@@ -75,6 +77,10 @@ struct ExpandingTextEditor: View {
                 .font(.caption)
                 .padding([.leading, .bottom], 12)
                 .opacity(state.showRequiredError && isRequiredField ? 1 : 0)
+        }
+        .clipShape(Rectangle()) // Allows taps in transparent areas so we can focus the keyboard
+        .onTapGesture {
+            isFocused = true    // Helps focus keyboard on the TextEditor that is smaller than the visuals when empty
         }
         .listRowSeparator(.hidden)
         .sheet(isPresented: $showSheet) {

--- a/Mage/ObservationEditCardCollectionViewController.swift
+++ b/Mage/ObservationEditCardCollectionViewController.swift
@@ -39,8 +39,8 @@ import MaterialComponents.MDCCard
     var formViews: [ObservationFormView] = [];
     var commonFieldView: CommonFieldsView?;
     private var keyboardHelper: KeyboardHelper?;
-    private var bottomConstraint: NSLayoutConstraint?;
-    
+    private let formBottomClearance: CGFloat = 60 // Padding for the Add Form button
+
     private lazy var event: Event? = {
         guard let observation = observation, let eventId = observation.eventId, let context = observation.managedObjectContext else {
             return nil
@@ -90,13 +90,11 @@ import MaterialComponents.MDCCard
     }()
     
     private func addStackViewConstraints() {
-        bottomConstraint = stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -60)
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            // Add room for the "Add Form" FAB
-            bottomConstraint!,
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -formBottomClearance), // Add room for the "Add Form" button
             stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
         ])
     }
@@ -158,24 +156,21 @@ import MaterialComponents.MDCCard
             guard let self = self else {
                 return;
             }
+            guard self.isViewLoaded, self.view.window != nil else {
+                return
+            }
             switch animation {
             case .keyboardWillShow:
                 self.navigationItem.rightBarButtonItem?.isEnabled = true;
-
-                if let firstResponder = self.stackView.firstResponder {
-                    let firstResponderPoint = self.scrollView.convert(CGPoint(x: 0, y: firstResponder.frame.origin.y + 20), from: firstResponder.superview);
-                    self.scrollView.setContentOffset(CGPoint(x:self.scrollView.contentOffset.x, y: firstResponderPoint.y - 60), animated: true);
-                } else {
-                    self.scrollView.contentOffset = CGPoint(x: self.scrollView.contentOffset.x, y: self.scrollView.contentOffset.y + keyboardFrame.height - 60)
-                }
+                self.updateKeyboardInsets(for: keyboardFrame)
+                self.scrollActiveFieldIntoView(duration: duration)
 
             case .keyboardWillHide:
                 self.navigationItem.rightBarButtonItem?.isEnabled = true;
-                self.bottomConstraint?.constant = -60;
-                self.view.layoutIfNeeded();
+                self.updateKeyboardInsets(for: .zero)
             
             case .keyboardDidShow:
-                NSLog("keyboard did show")
+                break
             }
         }
     }
@@ -434,9 +429,7 @@ import MaterialComponents.MDCCard
     }
 
     @objc func handleTapToDismissKeyboard() {
-        if let firstResponder = view.firstResponder {
-            firstResponder.resignFirstResponder()
-        }
+        view.endEditing(true)
     }
     
     func checkObservationValidity() -> Bool {
@@ -445,7 +438,11 @@ import MaterialComponents.MDCCard
         if let commonFieldView = commonFieldView {
             valid = commonFieldView.checkValidity(enforceRequired: true)
             if !valid {
-                scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: 0), animated: true)
+                if let invalidCommonField = commonFieldView.firstInvalidFieldView(enforceRequired: true) {
+                    scrollFieldIntoView(invalidCommonField, animated: true)
+                } else {
+                    scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: 0), animated: true)
+                }
                 scrolledToInvalidField = true
             }
         } else {
@@ -455,18 +452,17 @@ import MaterialComponents.MDCCard
             let formValid = formView.checkValidity(enforceRequired: true);
             valid = valid && formValid;
             if !formValid && !scrolledToInvalidField {
-                var yOffset:Double = 0.0
-                var fieldViews = Array(formView.fieldViews.values)
-                fieldViews.sort { ($0.field[FieldKey.id.key] as? Int ?? Int.max ) < ($1.field[FieldKey.id.key] as? Int ?? Int.max) }
-                for subview in fieldViews {
-                    if !subview.isValid(enforceRequired: true) && !scrolledToInvalidField {
-                        yOffset += Double(subview.frame.origin.y)
-                        yOffset += Double(-(bottomConstraint?.constant ?? 0.0))
-                        scrollView.setContentOffset(CGPoint(x: Double(scrollView.contentOffset.x), y: yOffset), animated: true)
-                        
-                        scrolledToInvalidField = true
-                    }
+                if let containingCard = formView.containingCard, !containingCard.expanded {
+                    containingCard.expanded = true
+                    view.layoutIfNeeded()
                 }
+                if let invalidFieldView = formView.firstInvalidFieldView(enforceRequired: true) {
+                    scrollFieldIntoView(invalidFieldView, animated: true)
+                } else {
+                    scrollFieldIntoView(formView, animated: true)
+                }
+                
+                scrolledToInvalidField = true
             }
         }
         
@@ -637,6 +633,71 @@ import MaterialComponents.MDCCard
         cards = [];
         setupObservation(observation: observation);
         addFormViews(stackView: stackView);
+    }
+}
+
+/// Keyboard Helper Utilities
+extension ObservationEditCardCollectionViewController {
+    var activeFieldRevealInset: CGFloat {
+        stackView.spacing
+    }
+
+    var validationFieldTopPadding: CGFloat {
+        stackView.directionalLayoutMargins.top + stackView.spacing
+    }
+
+    func updateKeyboardInsets(for keyboardFrame: CGRect) {
+        let keyboardBottomInset = keyboardOverlapHeight(for: keyboardFrame)
+        scrollView.contentInset.bottom = keyboardBottomInset > 0 ? keyboardBottomInset + formBottomClearance : 0
+        var verticalIndicatorInsets = scrollView.verticalScrollIndicatorInsets
+        verticalIndicatorInsets.bottom = keyboardBottomInset
+        scrollView.verticalScrollIndicatorInsets = verticalIndicatorInsets
+    }
+
+    func keyboardOverlapHeight(for keyboardFrame: CGRect) -> CGFloat {
+        guard keyboardFrame != .zero else {
+            return 0
+        }
+
+        let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
+        let intersection = view.bounds.intersection(keyboardFrameInView)
+        let overlap = max(0, intersection.height - view.safeAreaInsets.bottom)
+        return overlap
+    }
+
+    func scrollActiveFieldIntoView(duration: TimeInterval) {
+        guard let firstResponder = stackView.firstResponder else {
+            return
+        }
+
+        // Editing keeps the active field visible with the minimum required movement.
+        let originalResponderFrame = scrollView.convert(firstResponder.bounds, from: firstResponder)
+        let responderFrame = originalResponderFrame
+            .insetBy(dx: 0, dy: -activeFieldRevealInset)
+
+        UIView.animate(withDuration: duration) {
+            self.scrollView.scrollRectToVisible(responderFrame, animated: false)
+        }
+    }
+
+    func scrollFieldIntoView(_ targetView: UIView, animated: Bool) {
+        view.layoutIfNeeded()
+        let targetFrame = scrollView.convert(targetView.bounds, from: targetView)
+        // Validation aligns the invalid field near the top so the field state and snackbar are both visible.
+        let scrollTarget = ObservationValidationScrollTarget.topAligned(
+            for: targetFrame,
+            contentInset: scrollView.adjustedContentInset,
+            contentSize: scrollView.contentSize,
+            boundsSize: scrollView.bounds.size,
+            topPadding: validationFieldTopPadding
+        )
+        if animated {
+            UIView.animate(withDuration: 0.25) {
+                self.scrollView.setContentOffset(scrollTarget.offset, animated: false)
+            }
+        } else {
+            scrollView.setContentOffset(scrollTarget.offset, animated: false)
+        }
     }
 }
 

--- a/Mage/ObservationEditCardCollectionViewController.swift
+++ b/Mage/ObservationEditCardCollectionViewController.swift
@@ -58,6 +58,7 @@ import MaterialComponents.MDCCard
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.accessibilityIdentifier = "card scroll";
         scrollView.accessibilityLabel = "card scroll"
+        scrollView.keyboardDismissMode = .interactive
         return scrollView;
     }()
     

--- a/Mage/ObservationFormView.swift
+++ b/Mage/ObservationFormView.swift
@@ -23,7 +23,12 @@ class ObservationFormView: UIStackView {
     private var eventForm: Form?;
     private var form: [String: Any]!;
     private var formIndex: Int!;
+    // Refactor the fieldViews and fieldScrollTargets into one unified protocol so that we can scroll to any UI element regardless of framework.
     var fieldViews: [String: BaseFieldView] = [ : ];
+    private var fieldScrollTargets: [String: UIView] = [:]; // Includes UIView + SwiftUI view fields
+    private var hostedControllers: [UIViewController] = []
+    private var expandingTextEditorStates: [String: ExpandingTextEditorState] = [:];
+
     private weak var attachmentSelectionDelegate: AttachmentSelectionDelegate?;
     private weak var viewController: UIViewController!;
     private weak var fieldSelectionDelegate: FieldSelectionDelegate?;
@@ -33,8 +38,6 @@ class ObservationFormView: UIStackView {
     private var formFieldAdded: Bool = false;
     private var includeAttachmentFields: Bool = true;
     private var scheme: MDCContainerScheming?;
-    private var expandingTextEditorStates: [String: ExpandingTextEditorState] = [:];
-    private var hostedControllers: [UIViewController] = []
 
     private lazy var formFields: [[String: Any]] = {
         let fields: [[String: Any]] = self.eventForm?.fields ?? [];
@@ -80,6 +83,7 @@ class ObservationFormView: UIStackView {
             controller.removeFromParent()
         }
         hostedControllers.removeAll()
+        fieldScrollTargets = [:]
         super.removeFromSuperview();
         self.viewController = nil;
         self.attachmentSelectionDelegate = nil;
@@ -176,10 +180,14 @@ class ObservationFormView: UIStackView {
             if let baseFieldView = fieldView as? BaseFieldView, let key = fieldDictionary[FieldKey.name.key] as? String {
                 baseFieldView.applyTheme(withScheme: scheme)
                 fieldViews[key] = baseFieldView;
+                fieldScrollTargets[key] = baseFieldView;
                 formFieldAdded = true;
                 self.addArrangedSubview(baseFieldView);
             } else if let fieldView = fieldView {
-                MageLogger.misc.error("Unable to create BaseFieldView for field \(fieldDictionary)")
+                if let key = fieldDictionary[FieldKey.name.key] as? String {
+                    fieldScrollTargets[key] = fieldView
+                }
+                formFieldAdded = true;
                 self.addArrangedSubview(fieldView);
             }
             hostedController?.didMove(toParent: viewController)
@@ -228,6 +236,29 @@ class ObservationFormView: UIStackView {
         }
         containingCard?.markValid(valid);
         return valid;
+    }
+
+    func firstInvalidFieldView(enforceRequired: Bool = false) -> UIView? {
+        for fieldDictionary in formFields {
+            guard let key = fieldDictionary[FieldKey.name.key] as? String else {
+                continue
+            }
+
+            if fieldDictionary[FieldKey.type.key] as? String == FieldType.textarea.key {
+                let isRequired = fieldDictionary[FieldKey.required.key] as? Bool ?? false
+                let value = form[key] as? String ?? ""
+                if enforceRequired && isRequired && value.isEmpty {
+                    return fieldScrollTargets[key]
+                }
+                continue
+            }
+
+            if let fieldView = fieldViews[key], !fieldView.isValid(enforceRequired: enforceRequired) {
+                return fieldView
+            }
+        }
+
+        return nil
     }
 
     func focusNextTextField(after fieldView: BaseFieldView) -> Bool {
@@ -281,10 +312,11 @@ extension ObservationFormView: FieldSelectionDelegate {
 extension ObservationFormView: ObservationFormFieldListener {
     func fieldValueChanged(_ field: [String : Any], value: Any?) {
         var newProperties = self.observation.properties as? [String: Any];
+        let fieldName = field[FieldKey.name.key] as? String ?? ""
         if (value == nil) {
-            form.removeValue(forKey: field[FieldKey.name.key] as? String ?? "");
+            form.removeValue(forKey: fieldName);
         } else {
-            form[field[FieldKey.name.key] as? String ?? ""] = value;
+            form[fieldName] = value;
         }
         if var forms: [[String: Any]] = newProperties?[ObservationKey.forms.key] as? [[String: Any]],
            !forms.isEmpty {

--- a/Mage/ObservationFormView.swift
+++ b/Mage/ObservationFormView.swift
@@ -288,7 +288,9 @@ extension ObservationFormView: ObservationFormFieldListener {
         }
         if var forms: [[String: Any]] = newProperties?[ObservationKey.forms.key] as? [[String: Any]],
            !forms.isEmpty {
-            forms[0] = form
+            if forms.indices.contains(formIndex) {
+                forms[formIndex] = form
+            }
             newProperties?[ObservationKey.forms.key] = forms
             self.observation.properties = newProperties
             self.observationFormListener?.formUpdated(form, form: formIndex)

--- a/Mage/ObservationFormView.swift
+++ b/Mage/ObservationFormView.swift
@@ -34,6 +34,7 @@ class ObservationFormView: UIStackView {
     private var includeAttachmentFields: Bool = true;
     private var scheme: MDCContainerScheming?;
     private var expandingTextEditorStates: [String: ExpandingTextEditorState] = [:];
+    private var hostedControllers: [UIViewController] = []
 
     private lazy var formFields: [[String: Any]] = {
         let fields: [[String: Any]] = self.eventForm?.fields ?? [];
@@ -74,6 +75,11 @@ class ObservationFormView: UIStackView {
     }
     
     override func removeFromSuperview() {
+        hostedControllers.forEach { controller in
+            controller.willMove(toParent: nil)
+            controller.removeFromParent()
+        }
+        hostedControllers.removeAll()
         super.removeFromSuperview();
         self.viewController = nil;
         self.attachmentSelectionDelegate = nil;
@@ -96,6 +102,7 @@ class ObservationFormView: UIStackView {
         for fieldDictionary in self.formFields {
             let type = fieldDictionary[FieldKey.type.key] as! String;
             var value = self.form?[fieldDictionary[FieldKey.name.key] as! String]
+            var hostedController: UIViewController?
             
             // special case for attachments
             var unsentAttachments: [[String : AnyHashable]] = [];
@@ -140,8 +147,12 @@ class ObservationFormView: UIStackView {
                 let key = fieldDictionary[FieldKey.name.key] as? String ?? ""
                 let state = expandingTextEditorStates[key] ?? ExpandingTextEditorState()
                 expandingTextEditorStates[key] = state
-                let hc = UIHostingController(rootView: ExpandingTextEditor(field: fieldDictionary, value: value as? String ?? "", state: state, delegate: self))
-                fieldView = hc.view
+                hostedController = createExpandingTextEditor(
+                    for: fieldDictionary,
+                    value: value as? String ?? "",
+                    state: state
+                )
+                fieldView = hostedController?.view
             case FieldType.email.key:
                 fieldView = TextFieldView(field: fieldDictionary, editMode: editMode, delegate: self, value: value as? String, keyboardType: .emailAddress);
             case FieldType.password.key:
@@ -171,6 +182,7 @@ class ObservationFormView: UIStackView {
                 MageLogger.misc.error("Unable to create BaseFieldView for field \(fieldDictionary)")
                 self.addArrangedSubview(fieldView);
             }
+            hostedController?.didMove(toParent: viewController)
         }
     }
     
@@ -236,6 +248,27 @@ class ObservationFormView: UIStackView {
             }
         }
         return false
+    }
+
+    private func createExpandingTextEditor(
+        for fieldDictionary: [String: Any],
+        value: String,
+        state: ExpandingTextEditorState
+    ) -> UIViewController {
+        let hostingController = UIHostingController(
+            rootView: ExpandingTextEditor(
+                field: fieldDictionary,
+                value: value,
+                state: state,
+                delegate: self
+            )
+        )
+        // Child view controllers need to be tracked for proper view life cycle events (taps + visibility)
+        if let parentViewController = viewController {
+            parentViewController.addChild(hostingController)
+        }
+        hostedControllers.append(hostingController)
+        return hostingController
     }
 }
 

--- a/Mage/ObservationValidationScrollTarget.swift
+++ b/Mage/ObservationValidationScrollTarget.swift
@@ -1,0 +1,32 @@
+//
+//  ObservationValidationScrollTarget.swift
+//  MAGE
+//
+//  Created by Paul Solt on 3/13/26.
+//  Copyright © 2026 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+/// Used to help with scrolling to target elements onscreen
+struct ObservationValidationScrollTarget {
+    let offset: CGPoint
+    let verticalOffsetBounds: ClosedRange<CGFloat>
+
+    static func topAligned(
+        for targetFrame: CGRect,
+        contentInset: UIEdgeInsets,
+        contentSize: CGSize,
+        boundsSize: CGSize,
+        topPadding: CGFloat
+    ) -> ObservationValidationScrollTarget {
+        let minimumOffsetY = -contentInset.top
+        let maximumOffsetY = max(minimumOffsetY, contentSize.height - boundsSize.height + contentInset.bottom)
+        let verticalOffsetBounds = minimumOffsetY...maximumOffsetY
+        let unclampedOffsetY = targetFrame.minY - topPadding
+        let targetOffsetY = min(verticalOffsetBounds.upperBound, max(verticalOffsetBounds.lowerBound, unclampedOffsetY))
+
+        return ObservationValidationScrollTarget(
+            offset: CGPoint(x: 0, y: targetOffsetY),
+            verticalOffsetBounds: verticalOffsetBounds
+        )
+    }
+}

--- a/Mage/RadioFieldView.swift
+++ b/Mage/RadioFieldView.swift
@@ -112,6 +112,7 @@ class RadioFieldView: BaseFieldView {
     }
     
     @objc func handleRadioTap(_ button: MDCButton) {
+        dismissActiveEditing()
         for cb in choiceButtons {
             if (cb.value.button == button) {
                 value = cb.key;

--- a/MageTests/Observation/Edit/ObservationValidationScrollLayoutTests.swift
+++ b/MageTests/Observation/Edit/ObservationValidationScrollLayoutTests.swift
@@ -1,0 +1,64 @@
+//
+//  ObservationValidationScrollLayoutTests.swift
+//  MAGETests
+//
+//  Created by Codex on 3/12/26.
+//
+
+import XCTest
+
+@testable import MAGE
+
+final class ObservationValidationScrollLayoutTests: XCTestCase {
+    func testTargetOffsetAlignsFieldNearTopPadding() {
+        let targetOffset = ObservationValidationScrollTarget.topAligned(
+            for: CGRect(x: 24, y: 518, width: 382, height: 86),
+            contentInset: .zero,
+            contentSize: CGSize(width: 430, height: 2273.6666666666665),
+            boundsSize: CGSize(width: 430, height: 786),
+            topPadding: 16
+        ).offset
+
+        XCTAssertEqual(targetOffset.x, 0)
+        XCTAssertEqual(targetOffset.y, 502, accuracy: 0.001)
+    }
+
+    func testTargetOffsetClampsToBottomWhenLastFormCannotReachTopPadding() {
+        let targetOffset = ObservationValidationScrollTarget.topAligned(
+            for: CGRect(x: 24, y: 1914, width: 382, height: 86),
+            contentInset: .zero,
+            contentSize: CGSize(width: 430, height: 2271),
+            boundsSize: CGSize(width: 430, height: 785),
+            topPadding: 16
+        ).offset
+
+        XCTAssertEqual(targetOffset.x, 0)
+        XCTAssertEqual(targetOffset.y, 1486, accuracy: 0.001)
+    }
+
+    func testTargetOffsetClampsToTopForEarlyFields() {
+        let targetOffset = ObservationValidationScrollTarget.topAligned(
+            for: CGRect(x: 24, y: 10, width: 382, height: 86),
+            contentInset: .zero,
+            contentSize: CGSize(width: 430, height: 1500),
+            boundsSize: CGSize(width: 430, height: 785),
+            topPadding: 16
+        ).offset
+
+        XCTAssertEqual(targetOffset.x, 0)
+        XCTAssertEqual(targetOffset.y, 0, accuracy: 0.001)
+    }
+
+    func testTargetOffsetRespectsAdjustedInsetAtTop() {
+        let targetOffset = ObservationValidationScrollTarget.topAligned(
+            for: CGRect(x: 24, y: 20, width: 382, height: 86),
+            contentInset: UIEdgeInsets(top: 20, left: 0, bottom: 34, right: 0),
+            contentSize: CGSize(width: 430, height: 1400),
+            boundsSize: CGSize(width: 430, height: 785),
+            topPadding: 16
+        ).offset
+
+        XCTAssertEqual(targetOffset.x, 0)
+        XCTAssertEqual(targetOffset.y, 4, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
Fixes keyboard interactions on forms.

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1831

* Scrolling down and tapping a radio button doesn't snap back to a focused text field
* When saving a form, if a required field is empty, it will scroll to it correctly (even if the form is collapsed)
* Allows scrolling to all form fields, even at the bottom, because we adjust for the keyboard height.
* Tapping on non-keyboard fields now dismisses keyboards (checkboxes, multiple selection fields, dates, locations, etc)
* Removed the behavior that jumped focus to the next text field, as most forms are a mix of various form fields (this incorrectly skipped fields)
* Fixes toggle color for forms (Dark and light mode)
* Fixes scroll bug with multiple forms (previous crash fix)

## Tapping on non-TextFields will Dismiss Keyboard (and not snapback)
https://github.com/user-attachments/assets/11c42696-bc52-402d-a906-2916bd51fa0e

## Saving with required fields scrolls to blank required fields
https://github.com/user-attachments/assets/e0b7490c-b3cf-4418-b498-56a9da664549

