### PR TITLE
MAGE-1509 Fix Server URL issue when switching between servers

### DIFF
--- a/Mage/MageAppCoordinator.m
+++ b/Mage/MageAppCoordinator.m
@@ -108,6 +108,9 @@
 
 - (void) setServerURLWithUrl:(NSURL *)url {
     __weak __typeof__(self) weakSelf = self;
+    
+    [[UserUtility singleton] expireToken]; // Clear any previous authentication methods when switching servers
+    
     [MageServer serverWithUrl:url success:^(MageServer *mageServer) {
         [MageInitializer clearServerSpecificData];
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,10 +30,10 @@ PODS:
     - color-ios (~> 1.0.2)
     - sf-ios (~> 4.1.4)
   - HexColors (4.0.0)
-  - KIF (3.8.9):
-    - KIF/Core (= 3.8.9)
-  - KIF/Core (3.8.9)
-  - Kingfisher (7.10.1)
+  - KIF (3.12.3):
+    - KIF/Core (= 3.12.3)
+  - KIF/Core (3.12.3)
+  - Kingfisher (7.12.0)
   - libPhoneNumber-iOS (0.9.15)
   - MagicalRecord (2.3.2):
     - MagicalRecord/Core (= 2.3.2)
@@ -686,7 +686,7 @@ PODS:
     - MotionInterchange (~> 3.0)
   - MotionInterchange (3.0.0)
   - Nimble (9.2.1)
-  - OCMock (3.9.3)
+  - OCMock (3.9.4)
   - ogc-api-features-json-ios (4.2.5):
     - sf-geojson-ios (~> 4.2.5)
   - OHHTTPStubs (9.1.0):
@@ -808,8 +808,8 @@ SPEC CHECKSUMS:
   geopackage-ios: 8a61864c1f6e7433ddcd00854a27e23f78267b20
   grid-ios: 4aa398fd164bb8acac9d587cf61016cc6523defb
   HexColors: 5f95843ef89aff6a72e1fd3a8ebabf205cc43379
-  KIF: 7660c626b0f2d4562533590960db70a36d640558
-  Kingfisher: bc5abe80a8e0144537ef1dd5a0b2621b04f7f439
+  KIF: d7b36ad3b0ea6b48e0164e4a6b2cd1f0ec8272d2
+  Kingfisher: 53a10ea35051a436b5fb626ca2dd8f3144d755e9
   libPhoneNumber-iOS: 0a32a9525cf8744fe02c5206eb30d571e38f7d75
   MagicalRecord: 53bed74b4323b930992a725be713e53b37d19755
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
@@ -819,7 +819,7 @@ SPEC CHECKSUMS:
   MotionAnimator: 5f99d7c9592928c0f28a66283eda9c3b657dc480
   MotionInterchange: 13adae439b377e31d1674cc165539d50e1d1566a
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
-  OCMock: 300b1b1b9155cb6378660b981c2557448830bdc6
+  OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   ogc-api-features-json-ios: b53280f9036da5a7dc1699ea3a6cd90cdff0bfc9
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   PROJ: ca410c9aed8a01baf99746dad3d7c535a2dddaf0

--- a/sdk/Networking/MageSessionManager.m
+++ b/sdk/Networking/MageSessionManager.m
@@ -89,7 +89,11 @@ static NSDictionary<NSNumber *, NSArray<NSNumber *> *> * eventTasks;
 }
 
 -(void) setTokenInRequestSerializer: (AFHTTPRequestSerializer *) requestSerializer{
-    [requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", _token] forHTTPHeaderField:@"Authorization"];
+    if (_token != nil) {
+        [requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", _token] forHTTPHeaderField:@"Authorization"];
+    } else { // Clear authorization from http headers
+        [requestSerializer setValue:nil forHTTPHeaderField:@"Authorization"];
+    }
 }
 
 -(AFHTTPRequestSerializer *) httpRequestSerializer{


### PR DESCRIPTION
Clear previous authentication tokens when switching server URLs or when the token is set to nil. Make sure we clear the requestSerializer authorization when a token is nil, because it incorrectly attempts to authenticate with new server.

Fixes issue for the `develop_old` branch based on 4.2.0.

Fixes an issue where you cannot enter the URL for a different server after you have already logged into and out of another server. You have to quit the app before it lets you change servers.

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1509
<img width="1585" alt="401 error" src="https://github.com/user-attachments/assets/20e4ec0c-8a7e-4d91-86ae-3532378a5e3a" />

![failed to change servers](https://github.com/user-attachments/assets/66ccb0e1-0646-4071-97dc-c061f588b36e)

