### PR TITLE
1876.2 - Polygon fix prevent duplicate append

### DIFF
--- a/Mage/Mixins/FilteredObservationsMap.swift
+++ b/Mage/Mixins/FilteredObservationsMap.swift
@@ -26,8 +26,12 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
     
     var observations: Observations?
     var mapObservationManager: MapObservationManager
-    var lineObservations: [StyledPolyline] = []
-    var polygonObservations: [StyledPolygon] = []
+    private var pointAnnotationsByObjectID: [NSManagedObjectID: ObservationAnnotation] = [:]
+    private var lineObservationsByObjectID: [NSManagedObjectID: StyledPolyline] = [:]
+    private var polygonObservationsByObjectID: [NSManagedObjectID: StyledPolygon] = [:]
+    private var objectIDByRemoteID: [String: NSManagedObjectID] = [:]
+    var lineObservations: [StyledPolyline] { Array(lineObservationsByObjectID.values) }
+    var polygonObservations: [StyledPolygon] { Array(polygonObservationsByObjectID.values) }
     
     init(filteredObservationsMap: FilteredObservationsMap, user: User? = nil) {
         self.filteredObservationsMap = filteredObservationsMap
@@ -49,6 +53,10 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
         
         observations?.delegate = nil
         observations = nil
+        pointAnnotationsByObjectID.removeAll()
+        lineObservationsByObjectID.removeAll()
+        polygonObservationsByObjectID.removeAll()
+        objectIDByRemoteID.removeAll()
     }
     
     func setupMixin() {
@@ -142,31 +150,96 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
             }
         }
     }
+
+    /// Perform all work on the main thread
+    private func performMapMutation(_ mutation: () -> Void) {
+        if Thread.isMainThread {
+            mutation()
+        } else {
+            DispatchQueue.main.sync(execute: mutation)
+        }
+    }
+
+    /// We need a stable CoreData ID for any geometry, so we can prevent adding duplicates
+    private func stableObjectID(for observation: Observation) -> NSManagedObjectID {
+        if observation.objectID.isTemporaryID {
+            do {
+                try observation.managedObjectContext?.obtainPermanentIDs(for: [observation])
+            } catch {
+                NSLog("Failed to obtain permanent objectID for observation: \(error)")
+            }
+        }
+        return observation.objectID
+    }
+
+    private func trackedObjectID(for observation: Observation) -> NSManagedObjectID {
+        let objectID = stableObjectID(for: observation)
+        if let remoteId = observation.remoteId, let existingObjectID = objectIDByRemoteID[remoteId] {
+            return existingObjectID
+        }
+        return objectID
+    }
+
+    private func registerRemoteAlias(objectID: NSManagedObjectID, remoteId: String?) {
+        if let remoteId = remoteId {
+            objectIDByRemoteID[remoteId] = objectID
+        }
+    }
+
+    private func unregisterRemoteAlias(objectID: NSManagedObjectID, remoteId: String?) {
+        if let remoteId = remoteId, objectIDByRemoteID[remoteId] == objectID {
+            objectIDByRemoteID.removeValue(forKey: remoteId)
+        }
+    }
+
+    private func removeTrackedObservation(objectID: NSManagedObjectID, remoteId: String?) {
+        if let annotation = pointAnnotationsByObjectID.removeValue(forKey: objectID) {
+            filteredObservationsMap.mapView?.removeAnnotation(annotation)
+            unregisterRemoteAlias(objectID: objectID, remoteId: annotation.observationId ?? remoteId)
+            return
+        }
+
+        if let polyline = lineObservationsByObjectID.removeValue(forKey: objectID) {
+            filteredObservationsMap.mapView?.removeOverlay(polyline)
+            unregisterRemoteAlias(objectID: objectID, remoteId: polyline.observationRemoteId ?? remoteId)
+            return
+        }
+
+        if let polygon = polygonObservationsByObjectID.removeValue(forKey: objectID) {
+            filteredObservationsMap.mapView?.removeOverlay(polygon)
+            unregisterRemoteAlias(objectID: objectID, remoteId: polygon.observationRemoteId ?? remoteId)
+        }
+    }
     
     func updateObservation(observation: Observation, animated: Bool = false, zoom: Bool = false) {
+        let objectID = stableObjectID(for: observation)
         deleteObservation(observation: observation)
-        if let geometry = observation.geometry {
+        guard let geometry = observation.geometry else {
+            return
+        }
+
+        performMapMutation {
             if geometry.geometryType == SF_POINT {
                 let annotation = ObservationAnnotation(observation: observation, geometry: geometry)
-//                annotation.view.layer.zPosition = CGFloat(observation.timestamp?.timeIntervalSinceReferenceDate ?? 0)
                 annotation.animateDrop = animated
+                pointAnnotationsByObjectID[objectID] = annotation
+                registerRemoteAlias(objectID: objectID, remoteId: observation.remoteId)
                 filteredObservationsMap.mapView?.addAnnotation(annotation)
             } else {
                 let style = ObservationShapeStyleParser.style(of: observation)
                 let shapeConverter = GPKGMapShapeConverter()
                 let shape = shapeConverter?.toShape(with: geometry)
                 shapeConverter?.close()
-                
+
                 if let mkpolyline = shape?.shape as? MKPolyline {
                     let styledPolyline = StyledPolyline.create(polyline: mkpolyline)
                     styledPolyline.lineColor = style?.strokeColor ?? .black
                     styledPolyline.lineWidth = style?.lineWidth ?? 1
                     styledPolyline.observationRemoteId = observation.remoteId
                     styledPolyline.observation = observation
-                    lineObservations.append(styledPolyline)
-                    DispatchQueue.main.async { [weak self] in
-                        self?.filteredObservationsMap.mapView?.addOverlay(styledPolyline)
-                    }
+                    lineObservationsByObjectID[objectID] = styledPolyline
+                    registerRemoteAlias(objectID: objectID, remoteId: observation.remoteId)
+                    filteredObservationsMap.mapView?.addOverlay(styledPolyline)
                 } else if let mkpolygon = shape?.shape as? MKPolygon {
                     let styledPolygon = StyledPolygon.create(polygon: mkpolygon)
                     styledPolygon.lineColor = style?.strokeColor ?? .black
@@ -174,10 +247,9 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
                     styledPolygon.fillColor = style?.fillColor ?? .clear
                     styledPolygon.observation = observation
                     styledPolygon.observationRemoteId = observation.remoteId
-                    polygonObservations.append(styledPolygon)
-                    DispatchQueue.main.async { [weak self] in
-                        self?.filteredObservationsMap.mapView?.addOverlay(styledPolygon)
-                    }
+                    polygonObservationsByObjectID[objectID] = styledPolygon
+                    registerRemoteAlias(objectID: objectID, remoteId: observation.remoteId)
+                    filteredObservationsMap.mapView?.addOverlay(styledPolygon)
                 }
             }
         }
@@ -187,37 +259,9 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
     }
     
     func deleteObservation(observation: Observation) {
-        let annotation = filteredObservationsMap.mapView?.annotations.first(where: { annotation in
-            if let annotation = annotation as? ObservationAnnotation {
-                if let observationRemoteId = annotation.observationId {
-                    return observationRemoteId == observation.remoteId
-                }
-                
-                return annotation.observation?.objectID == observation.objectID
-            }
-            return false
-        })
-        
-        if let annotation = annotation {
-            filteredObservationsMap.mapView?.removeAnnotation(annotation)
-        } else {
-            // it might be a line
-            let polyline = lineObservations.first { polyline in
-                return polyline.observationRemoteId == observation.remoteId
-            }
-            
-            if let polyline = polyline {
-                filteredObservationsMap.mapView?.removeOverlay(polyline)
-            } else {
-                // it might be a polygon
-                let polygon = polygonObservations.first { polygon in
-                    return polygon.observationRemoteId == observation.remoteId
-                }
-                
-                if let polygon = polygon {
-                    filteredObservationsMap.mapView?.removeOverlay(polygon)
-                }
-            }
+        let objectID = trackedObjectID(for: observation)
+        performMapMutation {
+            removeTrackedObservation(objectID: objectID, remoteId: observation.remoteId)
         }
     }
     

--- a/MageTests/Map/Mixins/FilteredObservationsMapTests.swift
+++ b/MageTests/Map/Mixins/FilteredObservationsMapTests.swift
@@ -11,6 +11,7 @@ import Quick
 import Nimble
 import OHHTTPStubs
 import MagicalRecord
+import XCTest
 
 @testable import MAGE
 
@@ -699,5 +700,245 @@ class FilteredObservationsMapTests: KIFSpec {
                 }
             }
         }
+    }
+}
+
+@MainActor
+final class FilteredObservationsOverlayIdentityTests: XCTestCase {
+    private var navController: UINavigationController!
+    private var window: UIWindow!
+    private var controller: UIViewController!
+    private var mapTestImpl: FilteredObservationsMapTestImpl!
+    private var filteredObservationsMapMixin: FilteredObservationsMapMixin!
+    private var didSetupMixin = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        TestHelpers.clearAndSetUpStack()
+        window = TestHelpers.getKeyWindowVisible()
+        UserDefaults.standard.mapType = 0
+        UserDefaults.standard.themeOverride = 0
+        UserDefaults.standard.locationDisplay = .latlng
+        UserDefaults.standard.baseServerUrl = "https://magetest"
+
+        MageCoreDataFixtures.addEvent(remoteId: 1, name: "Event", formsJsonFile: "oneForm")
+        MageCoreDataFixtures.addUser(userId: "userabc")
+        MageCoreDataFixtures.addUserToEvent(eventId: 1, userId: "userabc")
+        Server.setCurrentEventId(1)
+        UserDefaults.standard.currentUserId = "userabc"
+
+        controller = UIViewController()
+        let mapView = MKMapView()
+        controller.view = mapView
+
+        mapTestImpl = FilteredObservationsMapTestImpl()
+        mapTestImpl.mapView = mapView
+        mapTestImpl.scheme = MAGEScheme.scheme()
+
+        filteredObservationsMapMixin = FilteredObservationsMapMixin(filteredObservationsMap: mapTestImpl)
+        mapTestImpl.filteredObservationsMapMixin = filteredObservationsMapMixin
+
+        navController = UINavigationController(rootViewController: controller)
+        window.rootViewController = navController
+        window.overrideUserInterfaceStyle = .unspecified
+        didSetupMixin = false
+    }
+
+    override func tearDownWithError() throws {
+        if didSetupMixin {
+            filteredObservationsMapMixin?.cleanupMixin()
+        }
+        filteredObservationsMapMixin = nil
+        mapTestImpl = nil
+        controller?.view.subviews.forEach { $0.removeFromSuperview() }
+        controller = nil
+        navController = nil
+        window?.resignKey()
+        window?.rootViewController = nil
+        window = nil
+        UserDefaults.standard.themeOverride = 0
+        TestHelpers.clearAndSetUpStack()
+        HTTPStubs.removeAllStubs()
+        try super.tearDownWithError()
+    }
+
+    private func polygonGeometry(centerLongitude: Double, centerLatitude: Double, delta: Double = 0.1) -> SFPolygon {
+        return SFPolygon(ring: SFLineString(points: [
+            SFPoint(xValue: centerLongitude + delta, andYValue: centerLatitude + delta) as Any,
+            SFPoint(xValue: centerLongitude - delta, andYValue: centerLatitude + delta) as Any,
+            SFPoint(xValue: centerLongitude - delta, andYValue: centerLatitude - delta) as Any,
+            SFPoint(xValue: centerLongitude + delta, andYValue: centerLatitude - delta) as Any,
+            SFPoint(xValue: centerLongitude + delta, andYValue: centerLatitude + delta) as Any
+        ]))
+    }
+
+    private func polylineGeometry(startLongitude: Double, startLatitude: Double, endLongitude: Double, endLatitude: Double) -> SFLineString {
+        return SFLineString(points: [
+            SFPoint(xValue: startLongitude, andYValue: startLatitude) as Any,
+            SFPoint(xValue: endLongitude, andYValue: endLatitude) as Any
+        ])
+    }
+
+    private func overlayCount<T>(of type: T.Type) -> Int {
+        return mapTestImpl.mapView?.overlays.filter { $0 is T }.count ?? 0
+    }
+
+    func testLocalPolygonRedrawKeepsSingleOverlay() {
+        let observation = Observation.create(geometry: polygonGeometry(centerLongitude: 16, centerLatitude: 21), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+
+        observation.geometry = polygonGeometry(centerLongitude: 17, centerLatitude: 22)
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+    }
+
+    func testDeletingOneLocalPolygonKeepsOtherPolygonVisible() {
+        let first = Observation.create(geometry: polygonGeometry(centerLongitude: 16, centerLatitude: 21), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+        let second = Observation.create(geometry: polygonGeometry(centerLongitude: 18, centerLatitude: 23), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: first)
+        filteredObservationsMapMixin.updateObservation(observation: second)
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(2))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(2))
+
+        filteredObservationsMapMixin.deleteObservation(observation: first)
+
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+        XCTAssertEqual(filteredObservationsMapMixin.polygonObservations.first?.observation, second)
+    }
+
+    func testDeletingLocalPolygonClearsBookkeeping() {
+        let observation = Observation.create(geometry: polygonGeometry(centerLongitude: 16, centerLatitude: 21), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.deleteObservation(observation: observation)
+
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(0))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(0))
+    }
+
+    func testLocalPolygonRemoteIdTransitionKeepsSingleOverlay() {
+        let observation = Observation.create(geometry: polygonGeometry(centerLongitude: 16, centerLatitude: 21), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+
+        observation.remoteId = "polygon-remote-id"
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.deleteObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(0))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(0))
+    }
+
+    func testFetchedPolygonRedrawsDoNotAccumulateOverlays() {
+        let observation = Observation.create(geometry: polygonGeometry(centerLongitude: 16, centerLatitude: 21), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+        observation.remoteId = "server-polygon"
+        UserDefaults.standard.observationTimeFilterKey = .all
+
+        filteredObservationsMapMixin.setupMixin()
+        didSetupMixin = true
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.addFilteredObservations()
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.addFilteredObservations()
+        expect(self.overlayCount(of: StyledPolygon.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.polygonObservations.count).toEventually(equal(1))
+    }
+
+    func testLocalPolylineRedrawKeepsSingleOverlay() {
+        let observation = Observation.create(geometry: polylineGeometry(startLongitude: 16, startLatitude: 21, endLongitude: 17, endLatitude: 22), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+
+        observation.geometry = polylineGeometry(startLongitude: 18, startLatitude: 23, endLongitude: 19, endLatitude: 24)
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+    }
+
+    func testDeletingOneLocalPolylineKeepsOtherPolylineVisible() {
+        let first = Observation.create(geometry: polylineGeometry(startLongitude: 16, startLatitude: 21, endLongitude: 17, endLatitude: 22), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+        let second = Observation.create(geometry: polylineGeometry(startLongitude: 18, startLatitude: 23, endLongitude: 19, endLatitude: 24), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: first)
+        filteredObservationsMapMixin.updateObservation(observation: second)
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(2))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(2))
+
+        filteredObservationsMapMixin.deleteObservation(observation: first)
+
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+        XCTAssertEqual(filteredObservationsMapMixin.lineObservations.first?.observation, second)
+    }
+
+    func testDeletingLocalPolylineClearsBookkeeping() {
+        let observation = Observation.create(geometry: polylineGeometry(startLongitude: 16, startLatitude: 21, endLongitude: 17, endLatitude: 22), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.deleteObservation(observation: observation)
+
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(0))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(0))
+    }
+
+    func testLocalPolylineRemoteIdTransitionKeepsSingleOverlay() {
+        let observation = Observation.create(geometry: polylineGeometry(startLongitude: 16, startLatitude: 21, endLongitude: 17, endLatitude: 22), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+
+        observation.remoteId = "polyline-remote-id"
+        filteredObservationsMapMixin.updateObservation(observation: observation)
+
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.deleteObservation(observation: observation)
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(0))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(0))
+    }
+
+    func testFetchedPolylineRedrawsDoNotAccumulateOverlays() {
+        let observation = Observation.create(geometry: polylineGeometry(startLongitude: 16, startLatitude: 21, endLongitude: 17, endLatitude: 22), accuracy: 4.5, provider: "gps", delta: 2, context: NSManagedObjectContext.mr_default())
+        observation.remoteId = "server-polyline"
+        UserDefaults.standard.observationTimeFilterKey = .all
+
+        filteredObservationsMapMixin.setupMixin()
+        didSetupMixin = true
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.addFilteredObservations()
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
+
+        filteredObservationsMapMixin.addFilteredObservations()
+        expect(self.overlayCount(of: StyledPolyline.self)).toEventually(equal(1))
+        expect(self.filteredObservationsMapMixin.lineObservations.count).toEventually(equal(1))
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,138 @@
+SHELL := /bin/zsh
+.DEFAULT_GOAL := build-and-run
+
+WORKSPACE ?= MAGE.xcworkspace
+SCHEME ?= MAGE
+SIM_NAME ?= iPhone 17
+SIM_OS ?= 26.2
+DESTINATION ?= platform=iOS Simulator,name=$(SIM_NAME),OS=$(SIM_OS)
+DERIVED_DATA ?= build/DerivedData
+RESULT_BUNDLE_BASE ?= build/TestResults
+RESULT_STAMP ?= $(shell date +%Y%m%d-%H%M%S)
+RESULT_BUNDLE ?= $(RESULT_BUNDLE_BASE)-$(RESULT_STAMP).xcresult
+XCODEBUILD ?= xcodebuild
+TOOLS_PATH ?= /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+SIMCTL ?= xcrun simctl
+APP_NAME ?= MAGE
+APP_BUNDLE_ID ?= mil.nga.mage
+APP_PATH ?= $(DERIVED_DATA)/Build/Products/Debug-iphonesimulator/$(APP_NAME).app
+SIM_DEVICE_UDID ?= $(shell xcrun simctl list devices "iOS $(SIM_OS)" available | awk -v device="$(SIM_NAME)" -F '[()]' '{name=$$1; gsub(/^[[:space:]]+|[[:space:]]+$$/, "", name); if (name == device) {print $$2; exit}}')
+TEST_TARGETS ?=
+TEST_TARGET_BUNDLE ?= MAGETests
+
+.PHONY: help bootstrap check-tools list build test run build-and-run clean
+
+check-tools:
+	@command -v xcbeautify >/dev/null || { \
+		echo "Missing required tool: xcbeautify"; \
+		echo "Install with: make bootstrap"; \
+		echo "Or run: brew install xcbeautify"; \
+		exit 1; \
+	}
+
+bootstrap:
+	@command -v brew >/dev/null || { \
+		echo "Homebrew is required to install xcbeautify."; \
+		echo "Install Homebrew from: https://brew.sh"; \
+		exit 1; \
+	}
+	@brew list xcbeautify >/dev/null 2>&1 || brew install xcbeautify
+	@echo "xcbeautify ready: $$(command -v xcbeautify)"
+
+help:
+	@echo "make bootstrap # Install required local tool(s), currently xcbeautify"
+	@echo "make check-tools # Verify required local tool(s) are installed"
+	@echo "make list   # Show workspace schemes"
+	@echo "make build  # Build MAGE for $(SIM_NAME) simulator (iOS $(SIM_OS))"
+	@echo "make test   # Run targeted tests only; requires TEST_TARGETS, unique xcresult"
+	@echo "            # Pass TEST_TARGETS='TestClass testMethod'"
+	@echo "            # Multiple targets: separate entries with commas"
+	@echo "            # Example: make test TEST_TARGETS='FilteredObservationsOverlayIdentityTests'"
+	@echo "            # Example: make test TEST_TARGETS='MAGETests/FilteredObservationsOverlayIdentityTests/testLocalPolygonRedrawKeepsSingleOverlay'"
+	@echo "            # Example: make test TEST_TARGETS='FilteredObservationsOverlayIdentityTests testLocalPolygonRedrawKeepsSingleOverlay,OtherTestClass'"
+	@echo "make run    # Install and launch built app on a matching simulator"
+	@echo "make build-and-run # Build, install, and launch app"
+	@echo "make clean  # Clean derived data"
+
+list: check-tools
+	@set -o pipefail && \
+	PATH='$(TOOLS_PATH):$$PATH' $(XCODEBUILD) -list -workspace $(WORKSPACE) | xcbeautify
+
+build: check-tools
+	@mkdir -p build
+	@set -o pipefail && \
+	PATH='$(TOOLS_PATH):$$PATH' $(XCODEBUILD) \
+		-workspace $(WORKSPACE) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-derivedDataPath $(DERIVED_DATA) \
+		CODE_SIGNING_ALLOWED=NO \
+		build | xcbeautify
+
+test: check-tools
+	@mkdir -p build
+	@set -o pipefail && \
+	setopt extendedglob && \
+	if [[ -z "$(strip $(TEST_TARGETS))" ]]; then \
+		echo "TEST_TARGETS is required."; \
+		echo "Example: make test TEST_TARGETS='FilteredObservationsOverlayIdentityTests'"; \
+		echo "Example: make test TEST_TARGETS='MAGETests/FilteredObservationsOverlayIdentityTests/testLocalPolygonRedrawKeepsSingleOverlay'"; \
+		exit 1; \
+	fi && \
+	normalize_test_target() { \
+		local target="$$1"; \
+		target="$${target##[[:space:]]#}"; \
+		target="$${target%%[[:space:]]#}"; \
+		if [[ -z "$$target" ]]; then \
+			return; \
+		fi; \
+		if [[ "$$target" == */* ]]; then \
+			print -- "$$target"; \
+		elif [[ "$$target" == *" "* ]]; then \
+			local class_name="$${target%% *}"; \
+			local test_name="$${target#* }"; \
+			print -- "$(TEST_TARGET_BUNDLE)/$$class_name/$$test_name"; \
+		else \
+			print -- "$(TEST_TARGET_BUNDLE)/$$target"; \
+		fi; \
+	} && \
+	only_testing_args=() && \
+	raw_targets='$(TEST_TARGETS)' && \
+	targets=($${(@s:,:)raw_targets}) && \
+	for target in "$${targets[@]}"; do \
+		normalized_target="$$(normalize_test_target "$$target")" && \
+		if [[ -n "$$normalized_target" ]]; then \
+			only_testing_args+=("-only-testing:$$normalized_target"); \
+		fi; \
+	done && \
+	PATH='$(TOOLS_PATH):$$PATH' $(XCODEBUILD) \
+		-workspace $(WORKSPACE) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-derivedDataPath $(DERIVED_DATA) \
+		-resultBundlePath $(RESULT_BUNDLE) \
+		"$${only_testing_args[@]}" \
+		CODE_SIGNING_ALLOWED=NO \
+		test | xcbeautify
+
+run:
+	@if [ ! -d "$(APP_PATH)" ]; then \
+		echo "Built app not found at $(APP_PATH)"; \
+		echo "Run 'make build' first or use 'make build-and-run'."; \
+		exit 1; \
+	fi
+	@if [ -z "$(SIM_DEVICE_UDID)" ]; then \
+		echo "No available simulator found for $(SIM_NAME) on iOS $(SIM_OS)."; \
+		echo "Run: xcrun simctl list devices available"; \
+		exit 1; \
+	fi
+	@open -a Simulator
+	@$(SIMCTL) boot "$(SIM_DEVICE_UDID)" >/dev/null 2>&1 || true
+	@$(SIMCTL) bootstatus "$(SIM_DEVICE_UDID)" -b >/dev/null
+	@$(SIMCTL) install "$(SIM_DEVICE_UDID)" "$(APP_PATH)"
+	@$(SIMCTL) launch "$(SIM_DEVICE_UDID)" "$(APP_BUNDLE_ID)"
+
+build-and-run: build run
+
+clean:
+	@/bin/rm -rf build


### PR DESCRIPTION
# Main idea:
> fix duplicate/incorrect overlay handling by tracking geometry via stable object IDs (and remoteId aliases), ensure map updates happen on the main thread, and add tests + tooling to prove/automate the fix.

## What changed and why
- Filtered​Observations​Map​.swift:
  + Geometry tracking moved from plain arrays to dictionaries keyed by stable NSManaged​Object​ID (plus a remoteId alias map). This ensures a single overlay/annotation per observation even if it’s reloaded or its remote​Id changes. It also centralizes removal so updates don’t leave stale overlays.
- Main-thread safety:
  + A perform​Map​Mutation helper forces map mutations onto the main thread to avoid race/duplication issues.
- Cleanup:
  + cleanup​Mixin() now clears the new tracking dictionaries to prevent leaks/stale overlays.
- ​Filtered​Observations​Map​Tests​.swift:
  + Added a new Filtered​Observations​Overlay​Identity​Tests XCTestCase verifying overlays don’t accumulate, deletes remove only the right overlay, and remoteId transitions don’t create duplicates. This directly validates the new bookkeeping.
- **Makefile**:
  + Added automation targets for listing, building, testing (with targeted test selection), running the app, and bootstrapping xcbeautify.

<img width="245" alt="duplicates" src="https://github.com/user-attachments/assets/842791a9-2ca2-4e82-be9a-cd300bda269c" />
<img width="245" alt="too-many-layers" src="https://github.com/user-attachments/assets/f911456e-9f39-4f5c-ba66-673245dee97a" />
