### PR TITLE
Core Data Fix: Update mutation to happen with the same context

### DIFF
--- a/Mage/CoreData/Observation.swift
+++ b/Mage/CoreData/Observation.swift
@@ -1219,7 +1219,7 @@ enum State: Int, CustomStringConvertible {
             if let localObservation = self?.mr_(in: localContext),
                let user = User.fetchCurrentUser(context: localContext),
                let userRemoteId = user.remoteId {
-                if let important = self?.observationImportant {
+                if let important = localObservation.observationImportant {
                     important.dirty = true;
                     important.important = true;
                     important.userId = userRemoteId;
@@ -1252,7 +1252,7 @@ enum State: Int, CustomStringConvertible {
             if let localObservation = self?.mr_(in: localContext),
                let user = User.fetchCurrentUser(context: localContext),
                let userRemoteId = user.remoteId {
-                if let important = self?.observationImportant {
+                if let important = localObservation.observationImportant {
                     important.dirty = true;
                     important.important = false;
                     important.userId = userRemoteId;


### PR DESCRIPTION
Core Data Fix: Update observation mutation to happen with the same localContext.

App was crashing with `-com.apple.CoreData.ConcurrencyDebug 1` due to thread violation.

<img width="300" alt="Screenshot 2026-04-17 at 1 40 33 PM" src="https://github.com/user-attachments/assets/a99dbd6d-318d-4628-a00a-1cc00b3ae4d7" />
