### PR TITLE
Enable Core Data Debugging. [DISABLE before Release]

### DIFF
--- a/MAGE.xcodeproj/xcshareddata/xcschemes/MAGE.xcscheme
+++ b/MAGE.xcodeproj/xcshareddata/xcschemes/MAGE.xcscheme
@@ -70,6 +70,12 @@
             ReferencedContainer = "container:MAGE.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"


### PR DESCRIPTION
DISABLE BEFORE RELEASE

Enable Core Data Debugging:

`-com.apple.CoreData.ConcurrencyDebug 1`

If an error occurs, bring it up with the team, you can disable this setting in the Scheme editor (checkbox) to get past a blocking issue.

<img width="400" alt="Screenshot 2026-04-20 at 2 26 14 PM" src="https://github.com/user-attachments/assets/e4c7f457-32b8-4d1f-aac5-9c6b701b02a2" />

We need more insight to track down hard to reproduce core data issues. This will stop the app so that we can inspect concurrency issues with Core Data access (leads to crashes)