### PR TITLE
MAGE-1890: Fixes up Retain Cycles Between the Main Map and Mixins

### DIFF
--- a/Mage/AppDelegate.m
+++ b/Mage/AppDelegate.m
@@ -374,6 +374,7 @@
 
 - (void)tokenDidExpire:(NSNotification *)notification {
     [[Mage singleton] stopServices];
+    [[LocationService singleton] stop];
     [self.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
     [self createRootView];
 }

--- a/Mage/AttachmentCell.swift
+++ b/Mage/AttachmentCell.swift
@@ -57,6 +57,7 @@ import Kingfisher
     }
     
     override func removeFromSuperview() {
+        super.removeFromSuperview()
         self.imageView.cancel();
     }
     

--- a/Mage/MainMageMapView.swift
+++ b/Mage/MainMageMapView.swift
@@ -75,6 +75,7 @@ class MainMageMapView: MageMapView, FilteredObservationsMap, FilteredUsersMap, B
     }
     
     override func removeFromSuperview() {
+        super.removeFromSuperview()
         cleanupMapMixins()
         filteredObservationsMapMixin = nil
         filteredUsersMapMixin = nil

--- a/Mage/Map/MapObservationManager.m
+++ b/Mage/Map/MapObservationManager.m
@@ -17,7 +17,7 @@
 
 @interface MapObservationManager ()
 
-@property (nonatomic, strong) MKMapView *mapView;
+@property (nonatomic, weak) MKMapView *mapView;
 
 @end
 

--- a/Mage/Mixins/BottomSheetEnabled.swift
+++ b/Mage/Mixins/BottomSheetEnabled.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol BottomSheetEnabled {
+protocol BottomSheetEnabled: AnyObject {
     var mapView: MKMapView? { get set }
     var navigationController: UINavigationController?  { get set }
     var scheme: MDCContainerScheming? { get set }
@@ -16,7 +16,7 @@ protocol BottomSheetEnabled {
 }
 
 class BottomSheetMixin: NSObject, MapMixin {
-    var bottomSheetEnabled: BottomSheetEnabled
+    weak var bottomSheetEnabled: BottomSheetEnabled?
     var mapItemsTappedObserver: Any?
     var mapViewDisappearingObserver: Any?
     var mageBottomSheet: MageBottomSheetViewController?
@@ -35,7 +35,7 @@ class BottomSheetMixin: NSObject, MapMixin {
     
     func setupMixin() {
         mapItemsTappedObserver = NotificationCenter.default.addObserver(forName: .MapItemsTapped, object: nil, queue: .main) { [weak self] notification in
-            if let mapView = self?.bottomSheetEnabled.mapView, self?.isVisible(view: mapView) == true, let notification = notification.object as? MapItemsTappedNotification, notification.mapView == mapView {
+            if let mapView = self?.bottomSheetEnabled?.mapView, self?.isVisible(view: mapView) == true, let notification = notification.object as? MapItemsTappedNotification, notification.mapView == mapView {
                 var bottomSheetItems: [BottomSheetItem] = []
                 bottomSheetItems += self?.handleTappedAnnotations(annotations: notification.annotations) ?? []
                 bottomSheetItems += self?.handleTappedItems(items: notification.items) ?? []
@@ -43,13 +43,13 @@ class BottomSheetMixin: NSObject, MapMixin {
                     return
                 }
                 
-                let mageBottomSheet = MageBottomSheetViewController(items: bottomSheetItems, mapView: mapView, scheme: self?.bottomSheetEnabled.scheme)
+                let mageBottomSheet = MageBottomSheetViewController(items: bottomSheetItems, mapView: mapView, scheme: self?.bottomSheetEnabled?.scheme)
                 let bottomSheetNav = UINavigationController(rootViewController: mageBottomSheet)
                 let bottomSheet = MDCBottomSheetController(contentViewController: bottomSheetNav)
                 bottomSheet.navigationController?.navigationBar.isTranslucent = true
                 bottomSheet.delegate = self
                 bottomSheet.trackingScrollView = mageBottomSheet.scrollView
-                self?.bottomSheetEnabled.navigationController?.present(bottomSheet, animated: true, completion: nil)
+                self?.bottomSheetEnabled?.navigationController?.present(bottomSheet, animated: true, completion: nil)
                 self?.bottomSheet = bottomSheet
                 self?.mageBottomSheet = mageBottomSheet
                 self?.mapViewDisappearingObserver = NotificationCenter.default.addObserver(forName: .MapViewDisappearing, object: nil, queue: .main) { [weak self] notification in
@@ -123,13 +123,13 @@ class BottomSheetMixin: NSObject, MapMixin {
                 let featureItem = FeatureItem(annotation: annotation)
                 if !dedup.contains(featureItem) {
                     _ = dedup.insert(featureItem)
-                    let bottomSheetItem = BottomSheetItem(item: featureItem, actionDelegate: nil, annotationView: bottomSheetEnabled.mapView?.view(for: annotation))
+                    let bottomSheetItem = BottomSheetItem(item: featureItem, actionDelegate: nil, annotationView: bottomSheetEnabled?.mapView?.view(for: annotation))
                     items.append(bottomSheetItem)
                 }
             } else if let annotation = annotation as? FeedItem {
                 if !dedup.contains(annotation) {
                     _ = dedup.insert(annotation)
-                    let bottomSheetItem = BottomSheetItem(item: annotation, actionDelegate: nil, annotationView: bottomSheetEnabled.mapView?.view(for: annotation))
+                    let bottomSheetItem = BottomSheetItem(item: annotation, actionDelegate: nil, annotationView: bottomSheetEnabled?.mapView?.view(for: annotation))
                     items.append(bottomSheetItem)
                 }
             }

--- a/Mage/Mixins/FilteredObservationsMap.swift
+++ b/Mage/Mixins/FilteredObservationsMap.swift
@@ -10,14 +10,14 @@ import Foundation
 import MapKit
 import geopackage_ios
 
-protocol FilteredObservationsMap {
+protocol FilteredObservationsMap: AnyObject {
     var mapView: MKMapView? { get set }
     var scheme: MDCContainerScheming? { get set }
     var filteredObservationsMapMixin: FilteredObservationsMapMixin? { get set }
 }
 
 class FilteredObservationsMapMixin: NSObject, MapMixin {
-    var filteredObservationsMap: FilteredObservationsMap
+    weak var filteredObservationsMap: FilteredObservationsMap?
     var mapAnnotationFocusedObserver: AnyObject?
     var user: User?
     
@@ -67,7 +67,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
         UserDefaults.standard.addObserver(self, forKeyPath: #keyPath(UserDefaults.importantFilterKey), options: [.new], context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: #keyPath(UserDefaults.favoritesFilterKey), options: [.new], context: nil)
         mapAnnotationFocusedObserver = NotificationCenter.default.addObserver(forName: .MapAnnotationFocused, object: nil, queue: .main) { [weak self] notification in
-            if let notificationObject = (notification.object as? MapAnnotationFocusedNotification), notificationObject.mapView == self?.filteredObservationsMap.mapView {
+            if let notificationObject = (notification.object as? MapAnnotationFocusedNotification), notificationObject.mapView == self?.filteredObservationsMap?.mapView {
                 self?.focusAnnotation(annotation: notificationObject.annotation)
             } else if notification.object == nil {
                 self?.focusAnnotation(annotation: nil)
@@ -90,7 +90,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
 
     func items(at location: CLLocationCoordinate2D) -> [Any]? {
         let screenPercentage = UserDefaults.standard.shapeScreenClickPercentage
-        let tolerance = (self.filteredObservationsMap.mapView?.visibleMapRect.size.width ?? 0) * Double(screenPercentage)
+        let tolerance = (self.filteredObservationsMap?.mapView?.visibleMapRect.size.width ?? 0) * Double(screenPercentage)
         
         var annotations: [Any] = []
         for lineObservation in lineObservations {
@@ -194,19 +194,19 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
 
     private func removeTrackedObservation(objectID: NSManagedObjectID, remoteId: String?) {
         if let annotation = pointAnnotationsByObjectID.removeValue(forKey: objectID) {
-            filteredObservationsMap.mapView?.removeAnnotation(annotation)
+            filteredObservationsMap?.mapView?.removeAnnotation(annotation)
             unregisterRemoteAlias(objectID: objectID, remoteId: annotation.observationId ?? remoteId)
             return
         }
 
         if let polyline = lineObservationsByObjectID.removeValue(forKey: objectID) {
-            filteredObservationsMap.mapView?.removeOverlay(polyline)
+            filteredObservationsMap?.mapView?.removeOverlay(polyline)
             unregisterRemoteAlias(objectID: objectID, remoteId: polyline.observationRemoteId ?? remoteId)
             return
         }
 
         if let polygon = polygonObservationsByObjectID.removeValue(forKey: objectID) {
-            filteredObservationsMap.mapView?.removeOverlay(polygon)
+            filteredObservationsMap?.mapView?.removeOverlay(polygon)
             unregisterRemoteAlias(objectID: objectID, remoteId: polygon.observationRemoteId ?? remoteId)
         }
     }
@@ -224,7 +224,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
                 annotation.animateDrop = animated
                 pointAnnotationsByObjectID[objectID] = annotation
                 registerRemoteAlias(objectID: objectID, remoteId: observation.remoteId)
-                filteredObservationsMap.mapView?.addAnnotation(annotation)
+                filteredObservationsMap?.mapView?.addAnnotation(annotation)
             } else {
                 let style = ObservationShapeStyleParser.style(of: observation)
                 let shapeConverter = GPKGMapShapeConverter()
@@ -239,7 +239,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
                     styledPolyline.observation = observation
                     lineObservationsByObjectID[objectID] = styledPolyline
                     registerRemoteAlias(objectID: objectID, remoteId: observation.remoteId)
-                    filteredObservationsMap.mapView?.addOverlay(styledPolyline)
+                    filteredObservationsMap?.mapView?.addOverlay(styledPolyline)
                 } else if let mkpolygon = shape?.shape as? MKPolygon {
                     let styledPolygon = StyledPolygon.create(polygon: mkpolygon)
                     styledPolygon.lineColor = style?.strokeColor ?? .black
@@ -249,7 +249,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
                     styledPolygon.observationRemoteId = observation.remoteId
                     polygonObservationsByObjectID[objectID] = styledPolygon
                     registerRemoteAlias(objectID: objectID, remoteId: observation.remoteId)
-                    filteredObservationsMap.mapView?.addOverlay(styledPolygon)
+                    filteredObservationsMap?.mapView?.addOverlay(styledPolygon)
                 }
             }
         }
@@ -266,7 +266,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
     }
     
     func zoomAndCenterMap(observation: Observation?) {
-        if let mapView = filteredObservationsMap.mapView, let viewRegion = observation?.viewRegion(mapView: mapView) {
+        if let mapView = filteredObservationsMap?.mapView, let viewRegion = observation?.viewRegion(mapView: mapView) {
             mapView.setRegion(viewRegion, animated: true)
         }
     }
@@ -276,7 +276,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
             return nil
         }
         
-        let annotationView = observationAnnotation.viewForAnnotation(on: mapView, scheme: filteredObservationsMap.scheme ?? globalContainerScheme())
+        let annotationView = observationAnnotation.viewForAnnotation(on: mapView, scheme: filteredObservationsMap?.scheme ?? globalContainerScheme())
         
         // adjiust the center offset if this is the enlargedPin
         if (annotationView == self.enlargedObservationView) {
@@ -294,7 +294,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
               let observation = annotation.observation,
               let annotationView = annotation.view else {
             if let selectedObservationAccuracy = selectedObservationAccuracy {
-                filteredObservationsMap.mapView?.removeOverlay(selectedObservationAccuracy)
+                filteredObservationsMap?.mapView?.removeOverlay(selectedObservationAccuracy)
                 self.selectedObservationAccuracy = nil
             }
             if let enlargedObservationView = enlargedObservationView {
@@ -322,7 +322,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
         }
         
         if let selectedObservationAccuracy = selectedObservationAccuracy {
-            filteredObservationsMap.mapView?.removeOverlay(selectedObservationAccuracy)
+            filteredObservationsMap?.mapView?.removeOverlay(selectedObservationAccuracy)
         }
         
         enlargedObservationView = annotationView
@@ -330,7 +330,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
            let coordinate = observation.location?.coordinate
         {
             selectedObservationAccuracy = ObservationAccuracy(center: coordinate, radius: CLLocationDistance(truncating: accuracy))
-            filteredObservationsMap.mapView?.addOverlay(selectedObservationAccuracy!)
+            filteredObservationsMap?.mapView?.addOverlay(selectedObservationAccuracy!)
         }
 
         UIView.animate(withDuration: 0.5, delay: 0.0, options: .curveEaseInOut) {
@@ -343,7 +343,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
     func renderer(overlay: MKOverlay) -> MKOverlayRenderer? {
         if let overlay = overlay as? ObservationAccuracy {
             let renderer = ObservationAccuracyRenderer(overlay: overlay)
-            if let scheme = filteredObservationsMap.scheme {
+            if let scheme = filteredObservationsMap?.scheme {
                 renderer.applyTheme(withContainerScheme: scheme)
             }
             return renderer

--- a/Mage/Mixins/FilteredUsersMap.swift
+++ b/Mage/Mixins/FilteredUsersMap.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MapKit
 
-protocol FilteredUsersMap {
+protocol FilteredUsersMap: AnyObject {
     var mapView: MKMapView? { get set }
     var filteredUsersMapMixin: FilteredUsersMapMixin? { get set }
     func addFilteredUsers()
@@ -23,8 +23,8 @@ extension FilteredUsersMap {
 
 class FilteredUsersMapMixin: NSObject, MapMixin {
     var mapAnnotationFocusedObserver: AnyObject?
-    var filteredUsersMap: FilteredUsersMap?
-    var mapView: MKMapView?
+    weak var filteredUsersMap: FilteredUsersMap?
+    weak var mapView: MKMapView?
     var scheme: MDCContainerScheming?
     
     var enlargedLocationView: MKAnnotationView?

--- a/Mage/Mixins/GeoPackageBaseMap.swift
+++ b/Mage/Mixins/GeoPackageBaseMap.swift
@@ -9,13 +9,13 @@
 import Foundation
 import MapKit
 
-protocol GeoPackageBaseMap {
+protocol GeoPackageBaseMap: AnyObject {
     var mapView: MKMapView? { get set }
     var geoPackageBaseMapMixin: GeoPackageBaseMapMixin? { get set }
 }
 
 class GeoPackageBaseMapMixin: NSObject, MapMixin {
-    var mapView: MKMapView?
+    weak var mapView: MKMapView?
     var gridOverlay: MKTileOverlay?
     
     init(mapView: MKMapView?) {

--- a/Mage/Mixins/SingleObservationMap.swift
+++ b/Mage/Mixins/SingleObservationMap.swift
@@ -58,13 +58,13 @@ class SingleObservationMapMixin: FilteredObservationsMapMixin {
     override func updateObservation(observation: Observation, animated: Bool = false, zoom: Bool = false) {
         super.updateObservation(observation: observation, animated:animated, zoom: zoom)
         if let selectedObservationAccuracy = selectedObservationAccuracy {
-            filteredObservationsMap.mapView?.removeOverlay(selectedObservationAccuracy)
+            filteredObservationsMap?.mapView?.removeOverlay(selectedObservationAccuracy)
         }
         if let accuracy = observation.properties?[ObservationKey.accuracy.key] as? NSNumber,
            let coordinate = observation.location?.coordinate
         {
             selectedObservationAccuracy = ObservationAccuracy(center: coordinate, radius: CLLocationDistance(truncating: accuracy))
-            filteredObservationsMap.mapView?.addOverlay(selectedObservationAccuracy!)
+            filteredObservationsMap?.mapView?.addOverlay(selectedObservationAccuracy!)
         }
     }
 }

--- a/Mage/Mixins/UserTrackingMap.swift
+++ b/Mage/Mixins/UserTrackingMap.swift
@@ -10,15 +10,15 @@ import Foundation
 import MapKit
 import MaterialComponents
 
-protocol UserTrackingMap {
+protocol UserTrackingMap: AnyObject {
     var mapView: MKMapView? { get set }
     var navigationController: UINavigationController? { get }
     var userTrackingMapMixin: UserTrackingMapMixin? { get set }
 }
 
 class UserTrackingMapMixin: NSObject, MapMixin {
-    var mapView: MKMapView?
-    var userTrackingMap: UserTrackingMap
+    weak var mapView: MKMapView?
+    weak var userTrackingMap: UserTrackingMap?
     var scheme: MDCContainerScheming?
     weak var buttonParentView: UIStackView?
     var indexInView: Int = 0
@@ -86,11 +86,11 @@ class UserTrackingMapMixin: NSObject, MapMixin {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }
             }))
-            userTrackingMap.navigationController?.present(alert, animated: true, completion: nil)
+            userTrackingMap?.navigationController?.present(alert, animated: true, completion: nil)
             return
         }
         
-        guard let mapView = userTrackingMap.mapView else {
+        guard let mapView = userTrackingMap?.mapView else {
             return
         }
 

--- a/Mage/SearchMapView.swift
+++ b/Mage/SearchMapView.swift
@@ -57,6 +57,7 @@ class SearchMapView: MageMapView, HasMapSearch {
     }
     
     override func removeFromSuperview() {
+        super.removeFromSuperview()
         cleanupMapMixins()
         hasMapSearchMixin = nil
     }

--- a/Mage/SingleFeatureMapView.swift
+++ b/Mage/SingleFeatureMapView.swift
@@ -69,6 +69,7 @@ class SingleFeatureMapView: MageMapView, GeoPackageLayerMap, OnlineLayerMap, Fil
     }
     
     override func removeFromSuperview() {
+        super.removeFromSuperview()
         cleanupMapMixins()
         geoPackageLayerMapMixin = nil
         onlineLayerMapMixin = nil

--- a/Mage/SingleUserMapView.swift
+++ b/Mage/SingleUserMapView.swift
@@ -38,6 +38,8 @@ class SingleUserMapView: MageMapView, FilteredUsersMap, FilteredObservationsMap,
     }
     
     override func removeFromSuperview() {
+        super.removeFromSuperview()
+        cleanupMapMixins()
         filteredUsersMapMixin = nil
         filteredObservationsMapMixin = nil
         followUserMapMixin = nil


### PR DESCRIPTION
Fixes crashes related to retain cycles. Our location logic was trying to update UI that was already deallocated.

https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1890

* Location updates could fire with map UI that was already deallocated. 
* Uses weak references to prevent retain cycles (only `AnyObject` can be a `weak` reference type)
* Stops location updates when we are logged out "the next day"
* Cleans up mixins on single user map