### PR TITLE
1892 - OS 26.x done cancel buttons keyboard issues

### DIFF
--- a/Mage/DateView.swift
+++ b/Mage/DateView.swift
@@ -41,7 +41,7 @@ class DateView : BaseFieldView {
         return formatter;
     }()
     
-    private lazy var dateAccessoryView: UIToolbar = {2
+    private lazy var dateAccessoryView: UIToolbar = {
         // this frame is to prevent breaking constraints
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
         toolbar.autoSetDimension(.height, toSize: 50);

--- a/Mage/DateView.swift
+++ b/Mage/DateView.swift
@@ -41,10 +41,10 @@ class DateView : BaseFieldView {
         return formatter;
     }()
     
-    private lazy var dateAccessoryView: UIToolbar = {
+    private lazy var dateAccessoryView: UIToolbar = {2
         // this frame is to prevent breaking constraints
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 44);
+        toolbar.autoSetDimension(.height, toSize: 50);
         
         let doneBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed));
         let cancelBarButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed));

--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -42,7 +42,7 @@ class NumberFieldView : BaseFieldView {
     
     private lazy var accessoryView: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 44);
+        toolbar.autoSetDimension(.height, toSize: 50);
         
         let doneBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed));
         let cancelBarButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed));

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -63,7 +63,7 @@ class TextFieldView : BaseFieldView {
     
     private lazy var accessoryView: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 44);
+        toolbar.autoSetDimension(.height, toSize: 50);
         
         let doneBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed));
         doneBarButton.accessibilityLabel = "Done";


### PR DESCRIPTION
# 1892 - OS 26.x done cancel buttons keyboard issues
- just had to modify a single height value
- updated all views that use a keyboard and have donecancel buttons

## Before
<img width="240" alt="textfield_done_cancel_buttons" src="https://github.com/user-attachments/assets/e508831d-0d55-4a8e-9ff2-cce315c92e27" /> <img width="240" alt="numberfield_done_cancel_buttons" src="https://github.com/user-attachments/assets/53059b64-e21e-42e2-a4ef-c6ed13cbf08c" />

## After
<img width="240" alt="textfield_after" src="https://github.com/user-attachments/assets/3fa103a0-690a-4abe-8c6d-d6b763a9ab53" /> <img width="240" alt="numberfield_after" src="https://github.com/user-attachments/assets/9842f754-3858-460a-9cd2-049c104009f7" />


