### PR TITLE
Psolt/hotfix toggle security isolated

### DIFF
--- a/Mage/AuthenticationCoordinator.m
+++ b/Mage/AuthenticationCoordinator.m
@@ -106,8 +106,6 @@ BOOL signingIn = YES;
     
     NSString *url = [NSString stringWithFormat:@"%@/%@", [MageServer baseURL], @"api/users/signups/verifications"];
     
-    NSLog(@"Parameters to sign up with %@", parameters);
-
     MageSessionManager *manager = [MageSessionManager sharedManager];
     NSMutableURLRequest *request = [manager.requestSerializer requestWithMethod:@"POST" URLString:url parameters:parameters error:nil];
     [request setValue:[NSString stringWithFormat:@"Bearer %@", self.captchaToken] forHTTPHeaderField:@"Authorization"];

--- a/Mage/ChangePasswordView.xib
+++ b/Mage/ChangePasswordView.xib
@@ -125,18 +125,17 @@
                                     </connections>
                                 </textField>
                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="wrX-aK-a82">
-                                    <rect key="frame" x="20" y="114" width="51" height="31"/>
+                                    <rect key="frame" x="20" y="114" width="63" height="31"/>
                                     <accessibility key="accessibilityConfiguration" label="Show Current Password"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="31" id="Bmr-bc-O06"/>
-                                        <constraint firstAttribute="width" constant="49" id="LEr-Zr-X4j"/>
                                     </constraints>
                                     <connections>
                                         <action selector="showCurrentPasswordChanged:" destination="-1" eventType="valueChanged" id="8CT-z5-sMi"/>
                                     </connections>
                                 </switch>
                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Current Password" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E6y-ZF-lif">
-                                    <rect key="frame" x="77" y="119" width="278" height="21"/>
+                                    <rect key="frame" x="89" y="119" width="266" height="21"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="21" id="Z2B-Na-fhs"/>
                                     </constraints>


### PR DESCRIPTION
1. Show password toggle is clipping on "Change Password" screen. (I missed the top toggle in my previous iOS 26 bug fix)
2. We are leaking user passwords to Console in plaintext, since ~2021. On any previous version from at least 2021, app logs will have user passwords after new user creation.

## Before
<img width="300" alt="2026-4-28 toggle clipping" src="https://github.com/user-attachments/assets/d0755fab-3314-446b-ba7b-a9dd68e6caf0" />

## After

<img width="300" alt="2026-4-28 toggle fixed" src="https://github.com/user-attachments/assets/d3cdf150-c4e1-4a1d-a1d5-1b1e31788037" />
