### PR TITLE
Fixes the Dark Mode Cursor Color

### DIFF
--- a/Mage/ChangePasswordViewController.m
+++ b/Mage/ChangePasswordViewController.m
@@ -64,6 +64,11 @@
     self.passwordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.confirmPasswordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.currentPasswordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    
+    self.usernameField.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.passwordField.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.currentPasswordField.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.confirmPasswordField.tintColor = self.scheme.colorScheme.onSurfaceColor;
 
     self.mageLabel.textColor = self.scheme.colorScheme.primaryColorVariant;
     self.wandLabel.textColor = self.scheme.colorScheme.primaryColorVariant;

--- a/Mage/ChangePasswordViewController.m
+++ b/Mage/ChangePasswordViewController.m
@@ -59,6 +59,11 @@
     [self.passwordField applyThemeWithScheme:containerScheme];
     [self.currentPasswordField applyThemeWithScheme:containerScheme];
     [self.confirmPasswordField applyThemeWithScheme:containerScheme];
+    UIColor *placeholderTextColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    [self.usernameField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.passwordField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.currentPasswordField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.confirmPasswordField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
     
     self.usernameField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.passwordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];

--- a/Mage/GeometryEditViewController.m
+++ b/Mage/GeometryEditViewController.m
@@ -89,6 +89,8 @@ static NSString *garsTitle = @"GARS";
     [field applyThemeWithScheme:containerScheme];
     [field setFilledBackgroundColor:[containerScheme.colorScheme.surfaceColor colorWithAlphaComponent:0.87] forState:MDCTextControlStateNormal];
     [field setFilledBackgroundColor:[containerScheme.colorScheme.surfaceColor colorWithAlphaComponent:0.87] forState:MDCTextControlStateEditing];
+    UIColor *placeholderTextColor = [containerScheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    [field setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
     field.tintColor = containerScheme.colorScheme.onSurfaceColor;
 }
 

--- a/Mage/GeometryEditViewController.m
+++ b/Mage/GeometryEditViewController.m
@@ -89,6 +89,7 @@ static NSString *garsTitle = @"GARS";
     [field applyThemeWithScheme:containerScheme];
     [field setFilledBackgroundColor:[containerScheme.colorScheme.surfaceColor colorWithAlphaComponent:0.87] forState:MDCTextControlStateNormal];
     [field setFilledBackgroundColor:[containerScheme.colorScheme.surfaceColor colorWithAlphaComponent:0.87] forState:MDCTextControlStateEditing];
+    field.tintColor = containerScheme.colorScheme.onSurfaceColor;
 }
 
 - (void) applyThemeTextField: (MDCFilledTextField *) field {

--- a/Mage/LdapLoginView.m
+++ b/Mage/LdapLoginView.m
@@ -35,6 +35,9 @@
     }
     [self.usernameField applyThemeWithScheme:containerScheme];
     [self.passwordField applyThemeWithScheme:containerScheme];
+    UIColor *placeholderTextColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    [self.usernameField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.passwordField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
     
     self.usernameField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.passwordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];

--- a/Mage/LdapLoginView.m
+++ b/Mage/LdapLoginView.m
@@ -39,6 +39,9 @@
     self.usernameField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.passwordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     
+    self.usernameField.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.passwordField.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    
     self.showPasswordLabel.textColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     
     [self.authenticationButton applyThemeWithContainerScheme:containerScheme];

--- a/Mage/LocalLoginView.m
+++ b/Mage/LocalLoginView.m
@@ -34,7 +34,10 @@
     self.scheme = containerScheme;
     [self.usernameField applyThemeWithScheme:containerScheme];
     [self.passwordField applyThemeWithScheme:containerScheme];
-    
+    UIColor *placeholderTextColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    [self.usernameField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.passwordField setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+
     self.usernameField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.passwordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.usernameField.tintColor = self.scheme.colorScheme.onSurfaceColor;
@@ -202,4 +205,3 @@
 }
 
 @end
-

--- a/Mage/LocalLoginView.m
+++ b/Mage/LocalLoginView.m
@@ -37,6 +37,8 @@
     
     self.usernameField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.passwordField.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    self.usernameField.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.passwordField.tintColor = self.scheme.colorScheme.onSurfaceColor;
     
     self.showPasswordLabel.textColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.signupDescription.textColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];

--- a/Mage/ServerURLController.swift
+++ b/Mage/ServerURLController.swift
@@ -165,6 +165,7 @@ class ServerURLController: UIViewController {
         okButton.applyContainedTheme(withScheme: scheme)
         cancelButton.applyContainedTheme(withScheme: scheme)
         serverURL.applyTheme(withScheme: scheme)
+        serverURL.tintColor = scheme.colorScheme.onSurfaceColor
         serverURL.leadingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
         errorImage.tintColor = scheme.colorScheme.errorColor
         errorInfoLink.textColor = scheme.colorScheme.primaryColorVariant

--- a/Mage/ServerURLController.swift
+++ b/Mage/ServerURLController.swift
@@ -164,12 +164,18 @@ class ServerURLController: UIViewController {
         errorStatus.textColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
         okButton.applyContainedTheme(withScheme: scheme)
         cancelButton.applyContainedTheme(withScheme: scheme)
-        serverURL.applyTheme(withScheme: scheme)
-        serverURL.tintColor = scheme.colorScheme.onSurfaceColor
+        applyServerURLNormalTheme(with: scheme)
         serverURL.leadingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
         errorImage.tintColor = scheme.colorScheme.errorColor
         errorInfoLink.textColor = scheme.colorScheme.primaryColorVariant
         errorInfoLink.font = UIFont.systemFont(ofSize: 12)
+    }
+
+    private func applyServerURLNormalTheme(with scheme: MDCContainerScheming) {
+        serverURL.applyTheme(withScheme: scheme)
+        let placeholderTextColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+        serverURL.tintColor = scheme.colorScheme.onSurfaceColor
+        serverURL.setFloatingLabelColor(placeholderTextColor, for: .editing)
     }
     
     public override func viewDidLoad() {
@@ -197,7 +203,7 @@ class ServerURLController: UIViewController {
             cancelButton.isHidden = true
             serverURL.text = url?.absoluteString
         } else if let scheme = scheme {
-            serverURL.applyTheme(withScheme: scheme)
+            applyServerURLNormalTheme(with: scheme)
         }
         
         if let url = url {
@@ -299,7 +305,7 @@ class ServerURLController: UIViewController {
             progressView.startAnimating()
             delegate?.setServerURL(url: url)
             if let scheme = scheme {
-                serverURL.applyTheme(withScheme: scheme)
+                applyServerURLNormalTheme(with: scheme)
             }
         } else {
             showError(error: "Invalid URL")

--- a/Mage/SignUpViewController.m
+++ b/Mage/SignUpViewController.m
@@ -93,6 +93,14 @@
     self.email.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.phone.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.captchaText.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    
+    self.username.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.displayName.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.password.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.passwordConfirm.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.email.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.phone.tintColor = self.scheme.colorScheme.onSurfaceColor;
+    self.captchaText.tintColor = self.scheme.colorScheme.onSurfaceColor;
 
     self.captchaProgressView.backgroundColor = self.scheme.colorScheme.surfaceColor;
     self.captchaProgressLabel.textColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];

--- a/Mage/SignUpViewController.m
+++ b/Mage/SignUpViewController.m
@@ -85,6 +85,14 @@
     [self.email applyThemeWithScheme:containerScheme];
     [self.phone applyThemeWithScheme:containerScheme];
     [self.captchaText applyThemeWithScheme:containerScheme];
+    UIColor *placeholderTextColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
+    [self.username setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.displayName setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.password setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.passwordConfirm setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.email setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.phone setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
+    [self.captchaText setFloatingLabelColor:placeholderTextColor forState:MDCTextControlStateEditing];
     
     self.username.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];
     self.displayName.leadingView.tintColor = [self.scheme.colorScheme.onSurfaceColor colorWithAlphaComponent:0.6];


### PR DESCRIPTION
Fixes the dark mode cursor color on the following screens:

* Geometry editing
* New User Account
* Change Password
* Log In Screens (User/Password + LDAP)

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 12 05 49" src="https://github.com/user-attachments/assets/eea314d9-1ddb-4514-b214-0c77744bf46e" />
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 12 00 25" src="https://github.com/user-attachments/assets/632de991-67ff-4d69-b238-7efb3a7534e4" />
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 12 00 22" src="https://github.com/user-attachments/assets/ca19f1fa-b427-43e5-b018-5323cd05c7d9" />
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 12 00 15" src="https://github.com/user-attachments/assets/38060885-0f7c-4a99-97d4-4c3c9a52308c" />
