### PR TITLE
This fixes the build issues with 26.4

### DIFF
--- a/MAGE.xcodeproj/project.pbxproj
+++ b/MAGE.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -261,6 +261,7 @@
 		F730B94B2683D273004AD64A /* CardHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F730B94A2683D273004AD64A /* CardHeader.swift */; };
 		F730B94D2685196E004AD64A /* ObservationFormReorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F730B94C2685196E004AD64A /* ObservationFormReorderTests.swift */; };
 		F730B94F268523B2004AD64A /* MockObservationFormReorderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F730B94E268523B2004AD64A /* MockObservationFormReorderDelegate.swift */; };
+		F732E73B2FC9E8F600EA1D49 /* MGRS in Frameworks */ = {isa = PBXBuildFile; productRef = F732E73A2FC9E8F600EA1D49 /* MGRS */; };
 		F7331D0D2653137C00D645AC /* NavigationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7331D0C2653137C00D645AC /* NavigationSettingsViewController.swift */; };
 		F7331D0F2653EF2800D645AC /* ColorPickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7331D0E2653EF2800D645AC /* ColorPickerCell.swift */; };
 		F7331D1126540FF700D645AC /* ColorPickerCelliOS13.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7331D1026540FF700D645AC /* ColorPickerCelliOS13.swift */; };
@@ -501,7 +502,9 @@
 		F7DDF46D2746CABF00689550 /* ObservationPushDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DDF46C2746CABF00689550 /* ObservationPushDelegate.swift */; };
 		F7DDF46F2748023A00689550 /* ObservationImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DDF46E2748023A00689550 /* ObservationImageTests.swift */; };
 		F7DEF91D1912A6940026B9D0 /* preferences.plist in Resources */ = {isa = PBXBuildFile; fileRef = F7DEF91C1912A6940026B9D0 /* preferences.plist */; };
+		F7E0309E2FC9D2B00042A671 /* GARS in Frameworks */ = {isa = PBXBuildFile; productRef = F7E0309D2FC9D2B00042A671 /* GARS */; };
 		F7E0380C1992948A007CCF6C /* AttachmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E0380B1992948A007CCF6C /* AttachmentCell.swift */; };
+		F7E066892FC9CFE1008C876C /* GeoPackage in Frameworks */ = {isa = PBXBuildFile; productRef = F7E066882FC9CFE1008C876C /* GeoPackage */; };
 		F7E2970F1A8D0E3D000F62C6 /* UIBarButtonItem+IB.m in Sources */ = {isa = PBXBuildFile; fileRef = F7E2970E1A8D0E3D000F62C6 /* UIBarButtonItem+IB.m */; };
 		F7E2DF0725672C6900CD2ABA /* UIApplicationTopController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E2DF0625672C6900CD2ABA /* UIApplicationTopController.swift */; };
 		F7E2DF0B2575A13200CD2ABA /* ObservationEditCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E2DF0A2575A13200CD2ABA /* ObservationEditCoordinatorTests.swift */; };
@@ -703,7 +706,7 @@
 		2F763C8E1DD10D2900780250 /* SettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingsViewController.h; sourceTree = "<group>"; };
 		2F763C8F1DD10D2900780250 /* SettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsViewController.m; sourceTree = "<group>"; };
 		2F7AB0C01D12EF91006F99FC /* set_build_number.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = set_build_number.sh; path = Scripts/set_build_number.sh; sourceTree = "<group>"; };
-		2F7D5D642602566B00886844 /* SignupDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SignupDelegate.h; sourceTree = "<group>"; };
+		2F7D5D642602566B00886844 /* SignUpDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SignUpDelegate.h; sourceTree = "<group>"; };
 		2F7D5D8A26025A9800886844 /* SignUpViewController_Server5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SignUpViewController_Server5.h; sourceTree = "<group>"; };
 		2F7D5D8B26025A9800886844 /* SignUpViewController_Server5.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SignUpViewController_Server5.m; sourceTree = "<group>"; };
 		2F81C4221C692C30006897E7 /* AttributionsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AttributionsViewController.h; sourceTree = "<group>"; };
@@ -744,7 +747,7 @@
 		2FCDC35422C2866A004189AD /* AuthenticationButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuthenticationButton.h; sourceTree = "<group>"; };
 		2FCDC35522C2866A004189AD /* AuthenticationButton.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AuthenticationButton.m; sourceTree = "<group>"; };
 		2FCDC35722C2888C004189AD /* AuthenticationButton.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AuthenticationButton.xib; sourceTree = "<group>"; };
-		2FD37EC71DF0AC1700429653 /* MAGE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = MAGE.entitlements; path = ../MAGE/MAGE.entitlements; sourceTree = "<group>"; };
+		2FD37EC71DF0AC1700429653 /* MAGE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = MAGE.entitlements; path = ../Mage/MAGE.entitlements; sourceTree = "<group>"; };
 		2FD853791BE1571C00602CEA /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Roboto-Medium.ttf"; path = "Resources/Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		2FD9103A1D2421B600CFE797 /* UIImage+Thumbnail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Thumbnail.h"; sourceTree = "<group>"; };
 		2FD9103B1D2421B600CFE797 /* UIImage+Thumbnail.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Thumbnail.m"; sourceTree = "<group>"; };
@@ -1381,10 +1384,13 @@
 				F70EAF3D199D052D00909C8A /* MediaPlayer.framework in Frameworks */,
 				4C390F4A197DB7B000AB3CCB /* MessageUI.framework in Frameworks */,
 				F7A94DA118ADBD5400CB9EE0 /* MapKit.framework in Frameworks */,
+				F7E066892FC9CFE1008C876C /* GeoPackage in Frameworks */,
 				F7A94DAB18B5100B00CB9EE0 /* QuartzCore.framework in Frameworks */,
 				F7A94D6C18AD9CB000CB9EE0 /* CoreGraphics.framework in Frameworks */,
+				F7E0309E2FC9D2B00042A671 /* GARS in Frameworks */,
 				F7A94D7018AD9CB000CB9EE0 /* CoreData.framework in Frameworks */,
 				F7A94D6E18AD9CB000CB9EE0 /* UIKit.framework in Frameworks */,
+				F732E73B2FC9E8F600EA1D49 /* MGRS in Frameworks */,
 				F7A94D6A18AD9CB000CB9EE0 /* Foundation.framework in Frameworks */,
 				BFC94C4360074DCC5E09B8EA /* libPods-MAGE.a in Frameworks */,
 			);
@@ -1598,7 +1604,7 @@
 				F7467B7A209A2F0B00EABA63 /* OrView.h */,
 				F7467B7B209A2F0B00EABA63 /* OrView.m */,
 				2F2F58F51BFA504B00B78993 /* ServerURLController.swift */,
-				2F7D5D642602566B00886844 /* SignupDelegate.h */,
+				2F7D5D642602566B00886844 /* SignUpDelegate.h */,
 				2F320B6E1BEBB90300C7F66C /* SignUpViewController.h */,
 				2F320B6F1BEBB90300C7F66C /* SignUpViewController.m */,
 			);
@@ -2949,6 +2955,11 @@
 				en,
 			);
 			mainGroup = F7A94D5D18AD9CAF00CB9EE0;
+			packageReferences = (
+				F7E066872FC9CFE1008C876C /* XCRemoteSwiftPackageReference "geopackage-ios" */,
+				F7E0309C2FC9D2B00042A671 /* XCRemoteSwiftPackageReference "gars-ios" */,
+				F7E0309F2FC9D2BF0042A671 /* XCRemoteSwiftPackageReference "mgrs-ios" */,
+			);
 			productRefGroup = F7A94D6718AD9CB000CB9EE0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -3129,11 +3140,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents/MaterialIcons_ic_radio_button_unchecked.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents/MaterialIcons_ic_reorder.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents/MaterialIcons_ic_settings.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/PROJ/PROJ.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/gars-ios/gars-ios.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/geopackage-ios/geopackage-ios.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/mgrs-ios/mgrs-ios.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/proj-ios/proj-ios.bundle",
 				"${PODS_ROOT}/zxcvbn-ios/Zxcvbn/generated/adjacency_graphs.json",
 				"${PODS_ROOT}/zxcvbn-ios/Zxcvbn/generated/frequency_lists.json",
 			);
@@ -3161,11 +3167,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons_ic_radio_button_unchecked.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons_ic_reorder.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons_ic_settings.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PROJ.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gars-ios.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/geopackage-ios.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/mgrs-ios.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/proj-ios.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/adjacency_graphs.json",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/frequency_lists.json",
 			);
@@ -3203,11 +3204,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents/MaterialIcons_ic_radio_button_unchecked.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents/MaterialIcons_ic_reorder.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents/MaterialIcons_ic_settings.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/PROJ/PROJ.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/gars-ios/gars-ios.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/geopackage-ios/geopackage-ios.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/mgrs-ios/mgrs-ios.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/proj-ios/proj-ios.bundle",
 				"${PODS_ROOT}/zxcvbn-ios/Zxcvbn/generated/adjacency_graphs.json",
 				"${PODS_ROOT}/zxcvbn-ios/Zxcvbn/generated/frequency_lists.json",
 			);
@@ -3235,11 +3231,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons_ic_radio_button_unchecked.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons_ic_reorder.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons_ic_settings.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PROJ.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gars-ios.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/geopackage-ios.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/mgrs-ios.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/proj-ios.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/adjacency_graphs.json",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/frequency_lists.json",
 			);
@@ -3885,7 +3876,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = MAGE/MAGE.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Mage/MAGE.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -3898,7 +3889,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 4.2.2;
 				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/AFNetworking/AFNetworking.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/DateTools/DateTools.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/HexColors/HexColors.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MDFInternationalization/MDFInternationalization.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MDFTextAccessibility/MDFTextAccessibility.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MagicalRecord/MagicalRecord.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MaterialComponents/MaterialComponents.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MotionAnimator/MotionAnimator.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MotionInterchange/MotionInterchange.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/PureLayout/PureLayout.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/SSZipArchive/SSZipArchive.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/UIImage_Categories/UIImage-Categories.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/geopackage_ios/geopackage-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/libPhoneNumber_iOS/libPhoneNumber-iOS.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/ogc_api_features_json_ios/ogc-api-features-json-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/sf_geojson_ios/sf-geojson-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/sf_ios/sf-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/sf_proj_ios/sf-proj-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/sf_wkb_ios/sf-wkb-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/sf_wkt_ios/sf-wkt-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/tiff_ios/tiff-ios.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/zxcvbn_ios/zxcvbn-ios.modulemap\"";
+				OTHER_MODULE_VERIFIER_FLAGS = "$(inherited) \"-F${PODS_CONFIGURATION_BUILD_DIR}/DateTools\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/HexColors\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/Kingfisher\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MDFInternationalization\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MDFTextAccessibility\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MagicalRecord\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MotionAnimator\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MotionInterchange\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/PureLayout\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/SSZipArchive\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/UIImage-Categories\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/libPhoneNumber-iOS\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/zxcvbn-ios\"";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/DateTools/DateTools.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/HexColors/HexColors.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MDFInternationalization/MDFInternationalization.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MDFTextAccessibility/MDFTextAccessibility.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MagicalRecord/MagicalRecord.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MaterialComponents/MaterialComponents.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MotionAnimator/MotionAnimator.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/MotionInterchange/MotionInterchange.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/PureLayout/PureLayout.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/SSZipArchive/SSZipArchive.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/UIImage_Categories/UIImage-Categories.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/libPhoneNumber_iOS/libPhoneNumber-iOS.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/zxcvbn_ios/zxcvbn-ios.modulemap\"";
 				PRODUCT_BUNDLE_IDENTIFIER = mil.nga.mage;
 				PRODUCT_NAME = MAGE;
 				PROVISIONING_PROFILE = "";
@@ -3925,7 +3917,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = MAGE/MAGE.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Mage/MAGE.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -3938,6 +3930,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 4.2.2;
 				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_MODULE_VERIFIER_FLAGS = "$(inherited) \"-F${PODS_CONFIGURATION_BUILD_DIR}/DateTools\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/HexColors\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/Kingfisher\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MDFInternationalization\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MDFTextAccessibility\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MagicalRecord\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MaterialComponents\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MotionAnimator\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/MotionInterchange\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/PureLayout\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/SSZipArchive\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/UIImage-Categories\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/libPhoneNumber-iOS\" \"-F${PODS_CONFIGURATION_BUILD_DIR}/zxcvbn-ios\"";
 				PRODUCT_BUNDLE_IDENTIFIER = mil.nga.mage;
 				PRODUCT_NAME = MAGE;
 				PROVISIONING_PROFILE = "";
@@ -4013,7 +4006,11 @@
 				);
 				INFOPLIST_FILE = MAGETests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -4062,7 +4059,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = MAGETests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -4113,6 +4114,51 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F7E0309C2FC9D2B00042A671 /* XCRemoteSwiftPackageReference "gars-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ngageoint/gars-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+		F7E0309F2FC9D2BF0042A671 /* XCRemoteSwiftPackageReference "mgrs-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/danielbarela/mgrs-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+		F7E066872FC9CFE1008C876C /* XCRemoteSwiftPackageReference "geopackage-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ngageoint/geopackage-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F732E73A2FC9E8F600EA1D49 /* MGRS */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F7E0309F2FC9D2BF0042A671 /* XCRemoteSwiftPackageReference "mgrs-ios" */;
+			productName = MGRS;
+		};
+		F7E0309D2FC9D2B00042A671 /* GARS */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F7E0309C2FC9D2B00042A671 /* XCRemoteSwiftPackageReference "gars-ios" */;
+			productName = GARS;
+		};
+		F7E066882FC9CFE1008C876C /* GeoPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F7E066872FC9CFE1008C876C /* XCRemoteSwiftPackageReference "geopackage-ios" */;
+			productName = GeoPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		F79D2944282C57C9008FD45E /* mage-ios-sdk.xcdatamodeld */ = {

--- a/MAGE.xcworkspace/contents.xcworkspacedata
+++ b/MAGE.xcworkspace/contents.xcworkspacedata
@@ -7,7 +7,4 @@
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:MageTests/MAGE.xctestplan">
-   </FileRef>
 </Workspace>

--- a/MAGE.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MAGE.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,41 +1,139 @@
 {
-  "originHash" : "207c6ed47e45e25f40d2ab20afcc890a28577e7ad35a49d3145f40980c999e56",
+  "originHash" : "087cb8cb906ea384087960a64ee6f85a8fa44c753f8703abc99986e004f1cc74",
   "pins" : [
     {
-      "identity" : "alamofire",
+      "identity" : "color-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "location" : "https://github.com/ngageoint/color-ios",
       "state" : {
-        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-        "version" : "5.10.2"
-      }
-    },
-    {
-      "identity" : "exceptioncatcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sindresorhus/ExceptionCatcher",
-      "state" : {
-        "revision" : "3cd1997e3663078812efca8652af06104b5160bb",
-        "version" : "2.1.0"
-      }
-    },
-    
-    {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
-      "state" : {
-        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
-        "version" : "7.12.0"
-      }
-    },
-    {
-      "identity" : "swiftuikitview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AvdLee/SwiftUIKitView.git",
-      "state" : {
-        "revision" : "56f2a1f8e35d5c258f633e8472cd59345ed5ae59",
+        "revision" : "1c588dafaf599a32d9adc29880264281dfbf286f",
         "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "coordinate-reference-systems-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/coordinate-reference-systems-ios.git",
+      "state" : {
+        "revision" : "d0d8cd34710aa78adb1bef3cdb2bf09a18356fa0",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "gars-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/gars-ios",
+      "state" : {
+        "revision" : "475c819730e97cb2608f071ae999aaae7018a6b5",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "geopackage-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/geopackage-ios",
+      "state" : {
+        "revision" : "55ef7d9221dd4c7bf8eef30fff9d65482e19e8ec",
+        "version" : "9.0.0"
+      }
+    },
+    {
+      "identity" : "grid-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/grid-ios",
+      "state" : {
+        "revision" : "9370e0042a6c78588486d345ab1133f450889508",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "mgrs-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielbarela/mgrs-ios",
+      "state" : {
+        "revision" : "10b45c4d1f0149a71af71f824b88a4fbb4283c8f",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "ogc-api-features-json-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/ogc-api-features-json-ios",
+      "state" : {
+        "revision" : "fb7c085c30205d86dba22fdad38c4b63de1171de",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "proj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/PROJ.git",
+      "state" : {
+        "revision" : "336fced3634f438f81e0d435ad99658688d1cf71",
+        "version" : "9.4.2"
+      }
+    },
+    {
+      "identity" : "projections-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/projections-ios",
+      "state" : {
+        "revision" : "f05c424664072bbc9bd177c62f82368b08414253",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "simple-features-geojson-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/simple-features-geojson-ios",
+      "state" : {
+        "revision" : "fec8acaee9b793e402c3e4a7660883b9259a1c75",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "simple-features-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/simple-features-ios",
+      "state" : {
+        "revision" : "615127133c83122077dcf71daa53a9a93f05a347",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "simple-features-proj-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/simple-features-proj-ios",
+      "state" : {
+        "revision" : "61a4291a61dd60a1b17e804c68e1ad90ce078ebb",
+        "version" : "7.0.0"
+      }
+    },
+    {
+      "identity" : "simple-features-wkb-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/simple-features-wkb-ios",
+      "state" : {
+        "revision" : "5e33516668372d8c3b130e8f38237b65ae6b042a",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "simple-features-wkt-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/simple-features-wkt-ios",
+      "state" : {
+        "revision" : "b17eba292f15742853b604e3de2fa178f9eedeba",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "tiff-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ngageoint/tiff-ios",
+      "state" : {
+        "revision" : "2e019be5231352eef1854492bd25f80174b0f902",
+        "version" : "5.0.0"
       }
     }
   ],

--- a/Mage/AppDelegate.m
+++ b/Mage/AppDelegate.m
@@ -12,7 +12,7 @@
 #import <AFNetworking/AFNetworkActivityIndicatorManager.h>
 #import "MageSessionManager.h"
 #import "MagicalRecord+MAGE.h"
-#import "GPKGGeoPackageFactory.h"
+@import GeoPackage;
 #import "MageConstants.h"
 #import "MageOfflineObservationManager.h"
 #import "MageAppCoordinator.h"

--- a/Mage/BaseMapOverlay.swift
+++ b/Mage/BaseMapOverlay.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import geopackage_ios
+import GeoPackage
 
 @objc class BaseMapOverlay: GPKGFeatureOverlay, OverlayRenderable {
     var renderer: MKOverlayRenderer {

--- a/Mage/BottomSheets/GeoPackageFeatureBottomSheetView.swift
+++ b/Mage/BottomSheets/GeoPackageFeatureBottomSheetView.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import geopackage_ios
+import GeoPackage
 
 class GeoPackageFeatureBottomSheetView: BottomSheetView {
     
@@ -166,9 +166,9 @@ class GeoPackageFeatureBottomSheetView: BottomSheetView {
                     valueTextView.textContainerInset = UIEdgeInsets(top: 2, left: -4, bottom: 0, right: 0);
                     if let dataType = featureItem.featureDataTypes?[key] {
                         let gpkgDataType = GPKGDataTypes.fromName(dataType)
-                        if (gpkgDataType == GPKG_DT_BOOLEAN) {
+                        if (gpkgDataType == .DT_BOOLEAN) {
                             valueTextView.text = "\((value as? Int) == 0 ? "true" : "false")"
-                        } else if (gpkgDataType == GPKG_DT_DATE) {
+                        } else if (gpkgDataType == .DT_DATE) {
                             let dateDisplayFormatter = DateFormatter();
                             dateDisplayFormatter.dateFormat = "yyyy-MM-dd";
                             dateDisplayFormatter.timeZone = TimeZone(secondsFromGMT: 0);
@@ -176,7 +176,7 @@ class GeoPackageFeatureBottomSheetView: BottomSheetView {
                             if let date = value as? Date {
                                 valueTextView.text = "\(dateDisplayFormatter.string(from: date))"
                             }
-                        } else if (gpkgDataType == GPKG_DT_DATETIME) {
+                        } else if (gpkgDataType == .DT_DATETIME) {
                             valueTextView.text = "\((value as? NSDate)?.formattedDisplay() ?? value)";
                         } else {
                             valueTextView.text = "\(value)"

--- a/Mage/BottomSheets/GeoPackageFeatureItem.swift
+++ b/Mage/BottomSheets/GeoPackageFeatureItem.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 National Geospatial Intelligence Agency. All rights reserved.
 //
 
-import geopackage_ios
+import GeoPackage
 
 @objc class GeoPackageFeatureItem: NSObject {
     @objc public override init() {

--- a/Mage/CoreData/GPSLocation.swift
+++ b/Mage/CoreData/GPSLocation.swift
@@ -10,8 +10,8 @@ import Foundation
 import CoreData
 import UIKit
 import CoreTelephony
-import AFNetworking
-import sf_ios
+//import AFNetworking
+import SimpleFeatures
 
 @objc public class GPSLocation: NSManagedObject {
     

--- a/Mage/CoreData/Location.swift
+++ b/Mage/CoreData/Location.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreData
 import CoreLocation
-import sf_ios
+import SimpleFeatures
 import MagicalRecord
 
 @objc public class Location: NSManagedObject, Navigable {

--- a/Mage/CoreData/Observation.swift
+++ b/Mage/CoreData/Observation.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 import CoreData
-import sf_ios
+import SimpleFeatures
 import UIKit
 import MagicalRecord
-import geopackage_ios
+import GeoPackage
 
 enum State: Int, CustomStringConvertible {
     case Archive, Active

--- a/Mage/GeoPackage/GeoPackage.m
+++ b/Mage/GeoPackage/GeoPackage.m
@@ -7,19 +7,12 @@
 //
 
 #import "GeoPackage.h"
-#import "GPKGGeoPackageCache.h"
-#import "GPKGGeoPackageFactory.h"
+@import GeoPackage;
 #import "GeoPackageCacheOverlay.h"
 #import "GeoPackageTileTableCacheOverlay.h"
 #import "GeoPackageFeatureTableCacheOverlay.h"
-#import "GPKGOverlayFactory.h"
-#import "GPKGNumberFeaturesTile.h"
-#import "GPKGMapShapeConverter.h"
-#import "GPKGFeatureTileTableLinker.h"
-#import "GPKGTileBoundingBoxUtils.h"
-#import "GPKGMapUtils.h"
 #import "CacheOverlayUpdate.h"
-#import "PROJProjectionConstants.h"
+@import Projections;
 #import "XYZDirectoryCacheOverlay.h"
 
 @interface GeoPackage ()

--- a/Mage/GeoPackage/GeoPackageImporter.m
+++ b/Mage/GeoPackage/GeoPackageImporter.m
@@ -8,19 +8,12 @@
 
 #import "GeoPackageImporter.h"
 
-#import "GPKGGeoPackageFactory.h"
-#import "GPKGGeoPackageValidate.h"
+@import GeoPackage;
 #import "CacheOverlays.h"
 #import "GeoPackageCacheOverlay.h"
 #import "GeoPackageTableCacheOverlay.h"
 #import "GeoPackageTileTableCacheOverlay.h"
-#import "GPKGFeatureIndexManager.h"
 #import "GeoPackageFeatureTableCacheOverlay.h"
-#import "GPKGFeatureTileTableLinker.h"
-#import "GPKGExtendedRelationsDao.h"
-#import "GPKGRelationTypes.h"
-#import "GPKGRelatedTablesExtension.h"
-#import "GPKGMediaDao.h"
 #import "MageConstants.h"
 #import "XYZDirectoryCacheOverlay.h"
 #import <SSZipArchive/SSZipArchive.h>

--- a/Mage/Geocoder.swift
+++ b/Mage/Geocoder.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-import gars_ios
-import mgrs_ios
+import GARS
+import MGRS
 
 enum SearchResponseType {
     case mgrs

--- a/Mage/GeometryEditCoordinator.h
+++ b/Mage/GeometryEditCoordinator.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <MaterialComponents/MaterialContainerScheme.h>
-#import "SFGeometry.h"
+@import SimpleFeatures;
 #import <MapKit/MapKit.h>
 
 @protocol GeometryEditDelegate

--- a/Mage/GeometryEditCoordinator.m
+++ b/Mage/GeometryEditCoordinator.m
@@ -9,7 +9,7 @@
 #import "GeometryEditCoordinator.h"
 #import "GeometryEditViewController.h"
 #import "LocationService.h"
-#import "SFPoint.h"
+@import SimpleFeatures;
 #import "MAGE-Swift.h"
 
 @interface GeometryEditCoordinator() <SearchMapViewControllerDelegate>

--- a/Mage/GeometryEditMapDelegate.m
+++ b/Mage/GeometryEditMapDelegate.m
@@ -7,7 +7,7 @@
 //
 
 #import "GeometryEditMapDelegate.h"
-#import "GPKGMapPoint.h"
+@import GeoPackage;
 #import "MapShapePointAnnotationView.h"
 #import "ObservationShapeStyle.h"
 

--- a/Mage/GeometryEditViewController.m
+++ b/Mage/GeometryEditViewController.m
@@ -6,20 +6,17 @@
 
 #import "GeometryEditViewController.h"
 #import "LocationService.h"
-#import "SFPoint.h"
-#import "SFGeometryUtils.h"
+@import SimpleFeatures;
 #import "MapObservation.h"
 #import "MapObservationManager.h"
-#import "GPKGMapShapeConverter.h"
+@import GeoPackage;
+@import Projections;
 #import "MapShapePointsObservation.h"
 #import "MapAnnotationObservation.h"
 #import "MapShapePointAnnotationView.h"
-#import "PROJProjectionConstants.h"
-#import "SFGeometryEnvelopeBuilder.h"
 #import "ObservationShapeStyle.h"
 #import "UINavigationItem+Subtitle.h"
 #import "MapUtils.h"
-#import "GPKGGeoPackageFactory.h"
 #import "AppDelegate.h"
 #import <PureLayout/PureLayout.h>
 #import "MAGE-Swift.h"

--- a/Mage/GridSystems.swift
+++ b/Mage/GridSystems.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-import gars_ios
-import mgrs_ios
+import GARS
+import MGRS
 
 /**
  * Grid Systems support for GARS and MGRS grid tile overlays and coordinates

--- a/Mage/HasMapSearchMixin.swift
+++ b/Mage/HasMapSearchMixin.swift
@@ -9,8 +9,8 @@
 import Foundation
 import MapKit
 
-import mgrs_ios
-import gars_ios
+import MGRS
+import GARS
 
 protocol HasMapSearch {
     var mapView: MKMapView? { get set }

--- a/Mage/LocationAnnotation.m
+++ b/Mage/LocationAnnotation.m
@@ -8,7 +8,7 @@
 @import MaterialComponents;
 
 #import "LocationAnnotation.h"
-#import "SFGeometryUtils.h"
+@import SimpleFeatures;
 #import <PureLayout.h>
 #import "MAGE-Swift.h"
 

--- a/Mage/MAGE-Bridging-Header.h
+++ b/Mage/MAGE-Bridging-Header.h
@@ -13,10 +13,6 @@
 #import "MapObservationManager.h"
 #import "ObservationShapeStyleParser.h"
 
-// Not sure why this isn't getting added via the geopackage pod...
-#import "GPKGMapShapeConverter.h"
-#import "GPKGFeatureRowData.h"
-
 #import "MAGERoutes.h"
 #import "NotificationRequester.h"
 #import "FadeTransitionSegue.h"
@@ -26,7 +22,6 @@
 #import "NSDate+display.h"
 #import "Locations.h"
 #import "Observations.h"
-#import "SFGeometryUtils.h"
 #import "ExternalDevice.h"
 #import "MageSessionManager.h"
 #import "MapSettings.h"

--- a/Mage/MageMapView.swift
+++ b/Mage/MageMapView.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import geopackage_ios
+import GeoPackage
 import MapKit
 
 protocol OverlayRenderable {

--- a/Mage/Map/Cache/GeoPackageFeatureTableCacheOverlay.h
+++ b/Mage/Map/Cache/GeoPackageFeatureTableCacheOverlay.h
@@ -7,8 +7,7 @@
 //
 
 #import "GeoPackageTableCacheOverlay.h"
-#import "GPKGFeatureOverlayQuery.h"
-#import "GPKGMapShape.h"
+@import GeoPackage;
 #import "GeoPackageTileTableCacheOverlay.h"
 #import "MAGE-Swift.h"
 

--- a/Mage/Map/Cache/GeoPackageFeatureTableCacheOverlay.m
+++ b/Mage/Map/Cache/GeoPackageFeatureTableCacheOverlay.m
@@ -7,12 +7,7 @@
 //
 
 #import "GeoPackageFeatureTableCacheOverlay.h"
-#import "GPKGMapShapeConverter.h"
-#import "GPKGMapUtils.h"
-#import "GPKGProperties.h"
-#import "GPKGPropertyConstants.h"
-#import "GPKGDataColumnsDao.h"
-#import "GPKGGeoPackageFactory.h"
+@import GeoPackage;
 
 NSInteger const GEO_PACKAGE_FEATURE_TABLE_MAX_ZOOM = 21;
 

--- a/Mage/Map/Cache/GeoPackageTileTableCacheOverlay.h
+++ b/Mage/Map/Cache/GeoPackageTileTableCacheOverlay.h
@@ -7,7 +7,7 @@
 //
 
 #import "GeoPackageTableCacheOverlay.h"
-#import "GPKGFeatureOverlayQuery.h"
+@import GeoPackage;
 
 @interface GeoPackageTileTableCacheOverlay : GeoPackageTableCacheOverlay
 

--- a/Mage/Map/MapObservationManager.h
+++ b/Mage/Map/MapObservationManager.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "MapObservation.h"
 #import "MapAnnotation.h"
-#import "SFGeometry.h"
+@import SimpleFeatures;
 /**
  * Handles adding Observations to the map as markers or shapes
  *

--- a/Mage/Map/MapObservationManager.m
+++ b/Mage/Map/MapObservationManager.m
@@ -7,8 +7,8 @@
 //
 
 #import "MapObservationManager.h"
-#import "SFGeometryUtils.h"
-#import "GPKGMapShapeConverter.h"
+@import SimpleFeatures;
+@import GeoPackage;
 #import "MapShapeObservation.h"
 #import "MapAnnotationObservation.h"
 #import "ObservationShapeStyle.h"

--- a/Mage/Map/MapPolygonObservation.m
+++ b/Mage/Map/MapPolygonObservation.m
@@ -7,7 +7,7 @@
 //
 
 #import "MapPolygonObservation.h"
-#import "GPKGMapUtils.h"
+@import GeoPackage;
 
 @interface MapPolygonObservation ()
 

--- a/Mage/Map/MapPolylineObservation.m
+++ b/Mage/Map/MapPolylineObservation.m
@@ -7,8 +7,7 @@
 //
 
 #import "MapPolylineObservation.h"
-#import "GPKGMapShapeConverter.h"
-#import "GPKGMapUtils.h"
+@import GeoPackage;
 
 @interface MapPolylineObservation ()
 

--- a/Mage/Map/MapShapeObservation.h
+++ b/Mage/Map/MapShapeObservation.h
@@ -7,7 +7,7 @@
 //
 
 #import "MapObservation.h"
-#import "GPKGMapShape.h"
+@import GeoPackage;
 
 /**
  * Observation represented by a shape on the map

--- a/Mage/Map/MapShapeObservation.m
+++ b/Mage/Map/MapShapeObservation.m
@@ -9,7 +9,7 @@
 #import "MapShapeObservation.h"
 #import "MapPolylineObservation.h"
 #import "MapPolygonObservation.h"
-#import "PROJProjectionConstants.h"
+@import Projections;
 
 @interface MapShapeObservation ()
 

--- a/Mage/Map/MapShapePointsObservation.h
+++ b/Mage/Map/MapShapePointsObservation.h
@@ -7,7 +7,7 @@
 //
 
 #import "MapShapeObservation.h"
-#import "GPKGMapShapePoints.h"
+@import GeoPackage;
 
 @interface MapShapePointsObservation : MapShapeObservation
 

--- a/Mage/Map/MapUtils.h
+++ b/Mage/Map/MapUtils.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <MapKit/MapKit.h>
-#import "SFPolygon.h"
+@import SimpleFeatures;
 
 /**
  * Map utilities

--- a/Mage/Map/MapUtils.m
+++ b/Mage/Map/MapUtils.m
@@ -7,8 +7,8 @@
 //
 
 #import "MapUtils.h"
-#import "GPKGMapShapePoints.h"
-#import "SFLineString.h"
+@import SimpleFeatures;
+@import GeoPackage;
 
 @implementation MapUtils
 

--- a/Mage/Mixins/FilteredObservationsMap.swift
+++ b/Mage/Mixins/FilteredObservationsMap.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import MapKit
-import geopackage_ios
+import GeoPackage
 
 protocol FilteredObservationsMap: AnyObject {
     var mapView: MKMapView? { get set }
@@ -219,7 +219,7 @@ class FilteredObservationsMapMixin: NSObject, MapMixin {
         }
 
         performMapMutation {
-            if geometry.geometryType == SF_POINT {
+            if geometry.geometryType == .POINT {
                 let annotation = ObservationAnnotation(observation: observation, geometry: geometry)
                 annotation.animateDrop = animated
                 pointAnnotationsByObjectID[objectID] = annotation

--- a/Mage/Mixins/GeoPackageLayerMap.swift
+++ b/Mage/Mixins/GeoPackageLayerMap.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import MapKit
-import geopackage_ios
+import GeoPackage
 
 protocol GeoPackageLayerMap {
     var mapView: MKMapView? { get set }

--- a/Mage/Mixins/MapMixin.swift
+++ b/Mage/Mixins/MapMixin.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import MapKit
-import geopackage_ios
+import GeoPackage
 
 protocol MapMixin {
     func setupMixin()

--- a/Mage/Mixins/SFGeometryMap.swift
+++ b/Mage/Mixins/SFGeometryMap.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 import MapKit
-import geopackage_ios
-import sf_ios
+import GeoPackage
+import SimpleFeatures
 
 protocol SFGeometryMap {
     var mapView: MKMapView? { get set }

--- a/Mage/Mixins/SingleObservationMap.swift
+++ b/Mage/Mixins/SingleObservationMap.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import MapKit
-import geopackage_ios
+import GeoPackage
 
 //protocol SingleObservationMap {
 //    var mapView: MKMapView? { get set }

--- a/Mage/Mixins/StaticLayerMap.swift
+++ b/Mage/Mixins/StaticLayerMap.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MapKit
 import CoreData
-import geopackage_ios
+import GeoPackage
 
 protocol StaticLayerMap {
     var mapView: MKMapView? { get set }

--- a/Mage/OfflineMapTableViewController.m
+++ b/Mage/OfflineMapTableViewController.m
@@ -12,7 +12,7 @@
 #import "ChildCacheOverlayTableCell.h"
 #import "XYZDirectoryCacheOverlay.h"
 #import "GeoPackageCacheOverlay.h"
-#import "GPKGGeoPackageFactory.h"
+@import GeoPackage;
 #import "ObservationTableHeaderView.h"
 #import "MAGE-Swift.h"
 

--- a/MageTests/MageCoreDataFixtures.swift
+++ b/MageTests/MageCoreDataFixtures.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import MagicalRecord
-import sf_ios
+import SimpleFeatures
 import Quick
 import Nimble
 import OHHTTPStubs

--- a/MageTests/Mocks/MockGeometryEditCoordinator.swift
+++ b/MageTests/Mocks/MockGeometryEditCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import sf_ios
+import SimpleFeatures
 
 class MockGeometryEditCoordinator : GeometryEditCoordinator {
     var _currentGeometry: SFGeometry! = SFPoint(x: 1.0, andY: 1.0);

--- a/MageTests/Observation/Edit/GeometryEditViewControllerTests.swift
+++ b/MageTests/Observation/Edit/GeometryEditViewControllerTests.swift
@@ -200,7 +200,7 @@ class GeometryEditViewControllerTests: KIFSpec {
                 expect(mockGeometryEditDelegate.geometryEditCompleteCalled).to(beTrue());
                 let geometry: SFGeometry? = mockGeometryEditDelegate.geometryEditCompleteGeometry;
                 expect(geometry).toNot(beNil());
-                expect(geometry?.geometryType).to(equal(SF_POINT))
+                expect(geometry?.geometryType).to(equal(.POINT))
             }
             
             xit("create a line with long press") {
@@ -237,7 +237,7 @@ class GeometryEditViewControllerTests: KIFSpec {
                 expect(mockGeometryEditDelegate.geometryEditCompleteCalled).to(beTrue());
                 let geometry: SFGeometry? = mockGeometryEditDelegate.geometryEditCompleteGeometry;
                 expect(geometry).toNot(beNil());
-                expect(geometry?.geometryType).to(equal(SF_LINESTRING))
+                expect(geometry?.geometryType).to(equal(.LINESTRING))
             }
             
             // this test will not run in conjunction with other tests, the map will not drag
@@ -269,7 +269,7 @@ class GeometryEditViewControllerTests: KIFSpec {
                 expect(mockGeometryEditDelegate.geometryEditCompleteCalled).to(beTrue());
                 let geometry: SFGeometry? = mockGeometryEditDelegate.geometryEditCompleteGeometry;
                 expect(geometry).toNot(beNil());
-                expect(geometry?.geometryType).to(equal(SF_POLYGON))
+                expect(geometry?.geometryType).to(equal(.POLYGON))
                 let poly = geometry as? SFPolygon;
                 let linestrings: [SFLineString] = poly?.lineStrings() as? [SFLineString] ?? [];
                 expect(linestrings.count).to(equal(1));
@@ -311,7 +311,7 @@ class GeometryEditViewControllerTests: KIFSpec {
                 expect(mockGeometryEditDelegate.geometryEditCompleteCalled).to(beTrue());
                 let geometry: SFGeometry? = mockGeometryEditDelegate.geometryEditCompleteGeometry;
                 expect(geometry).toNot(beNil());
-                expect(geometry?.geometryType).to(equal(SF_POLYGON))
+                expect(geometry?.geometryType).to(equal(.POLYGON))
                 let poly = geometry as? SFPolygon;
                 let linestrings: [SFLineString] = poly?.lineStrings() as? [SFLineString] ?? [];
                 expect(linestrings.count).to(equal(1));

--- a/MageTests/Observation/Edit/ObservationEditCoordinatorTests.swift
+++ b/MageTests/Observation/Edit/ObservationEditCoordinatorTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Quick
 import Nimble
-import sf_ios
+import SimpleFeatures
 
 import MagicalRecord
 

--- a/MageTests/Observation/Edit/ObservationFormViewTests.swift
+++ b/MageTests/Observation/Edit/ObservationFormViewTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Quick
 import Nimble
-import sf_ios
+import SimpleFeatures
 //import Nimble_Snapshots
 
 @testable import MAGE

--- a/MageTests/Observation/Fields/GeometryViewTests.swift
+++ b/MageTests/Observation/Fields/GeometryViewTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Quick
 import Nimble
-import sf_ios
+import SimpleFeatures
 //import Nimble_Snapshots
 
 @testable import MAGE

--- a/MageTests/SDK/GeometryDeserializerTests.swift
+++ b/MageTests/SDK/GeometryDeserializerTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Quick
 import Nimble
-import sf_ios
+import SimpleFeatures
 
 @testable import MAGE
 

--- a/MageTests/SDK/GeometrySerializerTests.swift
+++ b/MageTests/SDK/GeometrySerializerTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Quick
 import Nimble
-import sf_ios
+import SimpleFeatures
 
 @testable import MAGE
 

--- a/MageTests/TestingAppDelegate.m
+++ b/MageTests/TestingAppDelegate.m
@@ -8,8 +8,7 @@
 
 #import "TestingAppDelegate.h"
 #import "MagicalRecord+MAGE.h"
-#import "GPKGGeoPackageManager.h"
-#import "GPKGGeoPackageFactory.h"
+@import GeoPackage;
 #import "MAGE-Swift.h"
 
 @interface TestingAppDelegate ()

--- a/Podfile
+++ b/Podfile
@@ -19,10 +19,6 @@ def common_pods
   pod "AFNetworking", "~> 4.0.1"
   pod "DateTools", "~> 2.0.0"
   pod "MagicalRecord", "~> 2.3.2"
-  pod 'geopackage-ios', '~> 8.0.6'
-  pod 'PROJ', :modular_headers => false
-  pod 'mgrs-ios', '~> 1.1.6'
-  pod 'gars-ios', '~> 1.1.5'
   pod 'SSZipArchive', '~> 2.2.2'
 end
 
@@ -48,12 +44,37 @@ post_install do |installer|
       config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
       config.build_settings['BITCODE_GENERATION_MODE'] = 'bitcode'
       config.build_settings['ENABLE_BITCODE'] = 'YES'
+
       # Fix Xcode 14 bundle code signing issue
       if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
         target.build_configurations.each do |config|
           config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
         end
       end
+
+      # ------ REMOVE ALL OF THIS WHEN AFNETWORKING IS REMOVED IT SHOULD BE REMOVED IN FAVOR OF Alamofire
+      # Fix 26.4 compiler error with AFNetworking
+      # Remove private netinet6/in6.h header (conflicts in iPhoneSimulator SDK >= 26.4s).
+      # netinet/in.h already covers the needed IPv6 definitions.
+      sessionmanager_m = File.join(File.dirname(__FILE__), 'Pods', 'AFNetworking', 'AFNetworking', 'AFHTTPSessionManager.m')
+      puts "[post_install] Patching #{sessionmanager_m} — exists: #{File.exist?(sessionmanager_m)}"
+      if File.exist?(sessionmanager_m)
+        File.chmod(0644, sessionmanager_m)
+        content = File.read(sessionmanager_m)
+        patched = content.gsub("#import <netinet6/in6.h>\n", "")
+        File.write(sessionmanager_m, patched)
+        puts "[post_install] Patch applied: #{!patched.include?('netinet6')}"
+      end
+      reachability_m = File.join(File.dirname(__FILE__), 'Pods', 'AFNetworking', 'AFNetworking', 'AFNetworkReachabilityManager.m')
+      puts "[post_install] Patching #{reachability_m} — exists: #{File.exist?(reachability_m)}"
+      if File.exist?(reachability_m)
+        File.chmod(0644, reachability_m)
+        content = File.read(reachability_m)
+        patched = content.gsub("#import <netinet6/in6.h>\n", "")
+        File.write(reachability_m, patched)
+        puts "[post_install] Patch applied: #{!patched.include?('netinet6')}"
+      end
+      # ------ END REMOVE
     end
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,21 +14,7 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - color-ios (1.0.2)
-  - crs-ios (1.0.5)
   - DateTools (2.0.0)
-  - gars-ios (1.1.5):
-    - grid-ios (~> 1.0.7)
-  - geopackage-ios (8.0.6):
-    - color-ios (~> 1.0.2)
-    - ogc-api-features-json-ios (~> 4.2.5)
-    - sf-proj-ios (~> 6.0.3)
-    - sf-wkb-ios (~> 4.1.4)
-    - sf-wkt-ios (~> 2.1.4)
-    - tiff-ios (~> 4.0.2)
-  - grid-ios (1.0.7):
-    - color-ios (~> 1.0.2)
-    - sf-ios (~> 4.1.4)
   - HexColors (4.0.0)
   - KIF (3.12.3):
     - KIF/Core (= 3.12.3)
@@ -680,15 +666,11 @@ PODS:
     - MDFTextAccessibility
   - MDFInternationalization (3.0.0)
   - MDFTextAccessibility (2.0.1)
-  - mgrs-ios (1.1.6):
-    - grid-ios (~> 1.0.7)
   - MotionAnimator (4.0.1):
     - MotionInterchange (~> 3.0)
   - MotionInterchange (3.0.0)
   - Nimble (9.2.1)
   - OCMock (3.9.4)
-  - ogc-api-features-json-ios (4.2.5):
-    - sf-geojson-ios (~> 4.2.5)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -704,34 +686,15 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - PROJ (9.4.0):
-    - PROJ-include (~> 9.4.0)
-  - PROJ-include (9.4.0)
-  - proj-ios (2.0.3):
-    - crs-ios (~> 1.0.5)
-    - PROJ (~> 9.4.0)
   - PureLayout (3.1.9)
   - Quick (4.0.0)
-  - sf-geojson-ios (4.2.5):
-    - sf-ios (~> 4.1.4)
-  - sf-ios (4.1.4)
-  - sf-proj-ios (6.0.3):
-    - proj-ios (~> 2.0.3)
-    - sf-ios (~> 4.1.4)
-  - sf-wkb-ios (4.1.4):
-    - sf-ios (~> 4.1.4)
-  - sf-wkt-ios (2.1.4):
-    - sf-ios (~> 4.1.4)
   - SSZipArchive (2.2.3)
-  - tiff-ios (4.0.2)
   - UIImage-Categories (0.0.1)
   - zxcvbn-ios (1.0.4)
 
 DEPENDENCIES:
   - AFNetworking (~> 4.0.1)
   - DateTools (~> 2.0.0)
-  - gars-ios (~> 1.1.5)
-  - geopackage-ios (~> 8.0.6)
   - HexColors (~> 4.0.0)
   - KIF
   - Kingfisher (~> 7.0)
@@ -739,12 +702,10 @@ DEPENDENCIES:
   - MagicalRecord (~> 2.3.2)
   - MaterialComponents
   - MDFInternationalization
-  - mgrs-ios (~> 1.1.6)
   - Nimble (~> 9)
   - OCMock
   - OHHTTPStubs
   - OHHTTPStubs/Swift
-  - PROJ
   - PureLayout
   - Quick (from `https://github.com/Quick/Quick.git`, commit `a0a5fc857cea079fbe973e4faa80b6ceaf17bd46`)
   - SSZipArchive (~> 2.2.2)
@@ -754,12 +715,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AFNetworking
-    - color-ios
-    - crs-ios
     - DateTools
-    - gars-ios
-    - geopackage-ios
-    - grid-ios
     - HexColors
     - KIF
     - Kingfisher
@@ -768,24 +724,13 @@ SPEC REPOS:
     - MaterialComponents
     - MDFInternationalization
     - MDFTextAccessibility
-    - mgrs-ios
     - MotionAnimator
     - MotionInterchange
     - Nimble
     - OCMock
-    - ogc-api-features-json-ios
     - OHHTTPStubs
-    - PROJ
-    - PROJ-include
-    - proj-ios
     - PureLayout
-    - sf-geojson-ios
-    - sf-ios
-    - sf-proj-ios
-    - sf-wkb-ios
-    - sf-wkt-ios
     - SSZipArchive
-    - tiff-ios
     - UIImage-Categories
     - zxcvbn-ios
 
@@ -801,12 +746,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  color-ios: 77715f5f4c5944b3c85396e9263bfa17a1bf2cfd
-  crs-ios: cd52ed8ad551387cf12bfd4903d503fa1dff48f9
   DateTools: 933ac9c490f21f92127cf690ccd8c397e0126caf
-  gars-ios: e0d3f6dd775864f42ef7869fef0b3a1b80038695
-  geopackage-ios: 8a61864c1f6e7433ddcd00854a27e23f78267b20
-  grid-ios: 4aa398fd164bb8acac9d587cf61016cc6523defb
   HexColors: 5f95843ef89aff6a72e1fd3a8ebabf205cc43379
   KIF: d7b36ad3b0ea6b48e0164e4a6b2cd1f0ec8272d2
   Kingfisher: 53a10ea35051a436b5fb626ca2dd8f3144d755e9
@@ -815,28 +755,17 @@ SPEC CHECKSUMS:
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   MDFInternationalization: d697c55307816222a55685c4ccb1044ffb030c12
   MDFTextAccessibility: f4bb4cc2194286651b59a215fdeaa0e05dc90ba5
-  mgrs-ios: ab6bc20f8c8d34f182a25bfb164e97a19a7492da
   MotionAnimator: 5f99d7c9592928c0f28a66283eda9c3b657dc480
   MotionInterchange: 13adae439b377e31d1674cc165539d50e1d1566a
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
-  ogc-api-features-json-ios: b53280f9036da5a7dc1699ea3a6cd90cdff0bfc9
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  PROJ: ca410c9aed8a01baf99746dad3d7c535a2dddaf0
-  PROJ-include: e7438fba489ea7c636495dc05d197840cdac04da
-  proj-ios: 2a8ea337e1b728e669bb0845a1bd12fabce6609d
   PureLayout: 5fb5e5429519627d60d079ccb1eaa7265ce7cf88
   Quick: 5dc45f9bc11236594a7acc99f7bd85ecdc9a477d
-  sf-geojson-ios: 94a1409bbc463ff5fabf8235815c3d7422d26de2
-  sf-ios: 03cc989b70b11d80ab80afc9db2086a621fa4703
-  sf-proj-ios: 6cd46b6b9c4bdefa2a8fb8bc65c3b9fd434eedad
-  sf-wkb-ios: 1f77406c680545b348803c70e4ddc2dde73a37ff
-  sf-wkt-ios: 85faef2380a4fd47e6237f692d13273d641ab4eb
   SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
-  tiff-ios: 1ad6750cd8bb3db75bd2977e40145813389786b9
   UIImage-Categories: 5103b772ae91894f4d650eb696b006f4a2487ec3
   zxcvbn-ios: fef98b7c80f1512ff0eec47ac1fa399fc00f7e3c
 
-PODFILE CHECKSUM: f16cca03e04b188f2a160d5cfebad79559bce7c3
+PODFILE CHECKSUM: 3378b11d28d63191d23cfb83b034a158d409aca6
 
 COCOAPODS: 1.16.2

--- a/sdk/GeometryDeserializer.swift
+++ b/sdk/GeometryDeserializer.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 National Geospatial-Intelligence Agency. All rights reserved.
 //
 
-import sf_ios
-import sf_geojson_ios
+import SimpleFeatures
+import SimpleFeaturesGeoJSON
 
 @objc public class GeometryDeserializer: NSObject {
     

--- a/sdk/GeometrySerializer.swift
+++ b/sdk/GeometrySerializer.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 National Geospatial-Intelligence Agency. All rights reserved.
 //
 
-import sf_ios
-import sf_geojson_ios
+import SimpleFeatures
+import SimpleFeaturesGeoJSON
 
 @objc public class GeometrySerializer: NSObject {
     


### PR DESCRIPTION
Integrates GeoPackage libraries Swift Package manager versions.
Currently uses the mgrs-ios branch located here: https://github.com/danielbarela/mgrs-ios which fixes the compiler errors in Xcode 26.4
Adds a patch to the Podfile to temporarily fix AFNetworking to compile.  AFNetworking should be removed and replaced at a later date.