### PR TITLE
fix: fetch only users for the current event instead of all users

### DIFF
--- a/Mage/CoreData/Location.swift
+++ b/Mage/CoreData/Location.swift
@@ -216,7 +216,7 @@ import MagicalRecord
                 
                 if (newUserFound) {
                     // for now if we find at least one new user lets just go grab the users again
-                    User.operationToFetchUsers(success: nil, failure: nil);
+                    User.operationToFetchCurrentEventUsers(success: nil, failure: nil);
                 }
             } completion: { contextDidSave, error in
                 NSLog("TIMING Saved Locations /api/events/\(currentEventId)/locations/users. Elapsed: \(saveStart.timeIntervalSinceNow) seconds")

--- a/Mage/CoreData/User.swift
+++ b/Mage/CoreData/User.swift
@@ -181,11 +181,14 @@ import Kingfisher
     }
     
     @discardableResult
-    @objc public static func operationToFetchUsers(success: ((URLSessionDataTask,Any?) -> Void)?, failure: ((URLSessionDataTask?, Error) -> Void)?) -> URLSessionDataTask? {
+    @objc public static func operationToFetchCurrentEventUsers(success: ((URLSessionDataTask,Any?) -> Void)?, failure: ((URLSessionDataTask?, Error) -> Void)?) -> URLSessionDataTask? {
         guard let baseURL = MageServer.baseURL() else {
             return nil
         }
-        let url = "\(baseURL.absoluteURL)/api/users";
+        guard let currentEventId = Server.currentEventId() else {
+            return nil
+        }
+        let url = "\(baseURL.absoluteURL)/api/events/\(currentEventId)/users";
         let manager = MageSessionManager.shared();
         let methodStart = Date()
         NSLog("TIMING Fetching Users @ \(methodStart)")
@@ -208,15 +211,6 @@ import Kingfisher
             }
             
             MagicalRecord.save { localContext in
-                // Get roles
-                var roleIdMap: [String : Role] = [:];
-                if let roles = Role.mr_findAll(in: localContext) as? [Role] {
-                    for role in roles {
-                        if let remoteId = role.remoteId {
-                            roleIdMap[remoteId] = role
-                        }
-                    }
-                }
                 // Get the user ids to query
                 var userIds: [String] = [];
                 for userJson in users {

--- a/sdk/Mage.swift
+++ b/sdk/Mage.swift
@@ -14,37 +14,39 @@ import Foundation
     }
     
     @objc public func startServices(initial: Bool) {
-        var tasks: [URLSessionDataTask] = []
-        
-        LocationService.singleton().start();
-        if let rolesPullTask = Role.operationToFetchRoles(success: nil, failure: nil) {
-            tasks.append(rolesPullTask);
-        }
-        
-        let usersPullTask = User.operationToFetchUsers { task, response in
-            NSLog("Done with the initial user fetch, start location and observation services")
-            LocationFetchService.singleton.start();
-            ObservationFetchService.singleton.start(initial: initial);
-        } failure: { task, error in
-            NSLog("Failed to pull users \(error)")
-            // start the fetch services anyway.  Attempting to pull the users before starting these
-            // will cut down on the individual user requests which will be kicked off if a location
-            // or observation shows up with an unknown user
-            LocationFetchService.singleton.start();
-            ObservationFetchService.singleton.start(initial: initial);
-        }
-        if let usersPullTask = usersPullTask {
-            tasks.append(usersPullTask)
-        }
-        
         fetchSettings()
-        
+        let startFetchServices = {
+            LocationFetchService.singleton.start();
+            ObservationFetchService.singleton.start(initial: initial);
+        }
+        if initial {
+            var tasks: [URLSessionDataTask] = [];
+            if let fetchRolesTask = Role.operationToFetchRoles(success: nil, failure: nil) {
+                tasks.append(fetchRolesTask)
+            }
+            if let fetchUsersTask = User.operationToFetchCurrentEventUsers(
+                success: { task, response in
+                    NSLog("initial user fetch complete")
+                    startFetchServices()
+                },
+                failure: { task, error in
+                    NSLog("initial user fetch failed: \(error)")
+                    startFetchServices();
+                }
+            ) {
+                tasks.append(fetchUsersTask);
+            }
+            if tasks.count > 0 {
+                let sessionTask = SessionTask(tasks: tasks, andMaxConcurrentTasks: 1);
+                MageSessionManager.shared().add(sessionTask);
+            }
+        }
+        else {
+            startFetchServices()
+        }
+        LocationService.singleton().start();
         ObservationPushService.singleton.start();
-        AttachmentPushService.singleton().start();
-        
-        let sessionTask = SessionTask(tasks: tasks, andMaxConcurrentTasks: 1);
-        MageSessionManager.shared().add(sessionTask);
-        
+        AttachmentPushService.singleton().start();        
         MageSessionManager.setEventTasks(nil);
     }
     
@@ -132,7 +134,7 @@ import Foundation
         manager?.add(task);
     }
     
-    func add(task: URLSessionTask, eventTasks: inout [NSNumber: [NSNumber]], event: Event) {
+    private func add(task: URLSessionTask, eventTasks: inout [NSNumber: [NSNumber]], event: Event) {
         guard let remoteId = event.remoteId else {
             return;
         }


### PR DESCRIPTION
This PR modifies the app startup behavior from fetching all users to fetching only users for the currently selected event.  Additionally, user fetch will occur only on initial load, rather than every time the app moves to the foreground.