### PR TITLE
iOS modifications for undo/redo text-field

### DIFF
--- a/Mage/AppDelegate.m
+++ b/Mage/AppDelegate.m
@@ -212,6 +212,7 @@
 
 - (void) applicationWillResignActive:(UIApplication *)application {
     application.applicationIconBadgeNumber = [MageOfflineObservationManager offlineObservationCount];
+    [[UIApplication sharedApplication] sendAction:@selector(resignFirstResponder) to:nil from:nil forEvent:nil];
 }
 
 - (void) applicationWillEnterForeground:(UIApplication *) application {

--- a/Mage/MaterialComponents/MAGEScheme.swift
+++ b/Mage/MaterialComponents/MAGEScheme.swift
@@ -33,6 +33,8 @@ func applicationAppearance(scheme: MDCContainerScheming?) {
     UINavigationBar.appearance().barTintColor = scheme.colorScheme.primaryColor;
     UINavigationBar.appearance().isTranslucent = false;
     UINavigationBar.appearance().tintColor = scheme.colorScheme.onPrimaryColor;
+
+    UIToolbar.appearance().tintColor = scheme.colorScheme.primaryColor;
     
     UINavigationBar.appearance().standardAppearance = appearance;
     UINavigationBar.appearance().scrollEdgeAppearance = appearance;

--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -10,11 +10,10 @@ import Foundation
 import MaterialComponents.MDCTextField;
 
 class NumberFieldView : BaseFieldView {
-    private var shouldResign: Bool = false;
     private var number: NSNumber?;
     private var min: NSNumber?;
     private var max: NSNumber?;
-    
+
     lazy var helperText: String? = {
         var helper: String? = nil;
         if (self.min != nil && self.max != nil) {
@@ -26,32 +25,46 @@ class NumberFieldView : BaseFieldView {
         }
         return helper;
     }()
-    
+
     lazy var titleLabel: UILabel = {
         let label = UILabel(forAutoLayout: ());
         label.text = helperText;
         label.sizeToFit();
         return label;
     }()
-    
+
     private lazy var formatter: NumberFormatter = {
         let formatter = NumberFormatter();
         formatter.numberStyle = .decimal;
         return formatter;
     }()
-    
+
     private lazy var accessoryView: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 50);
-        
-        let doneBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed));
-        let cancelBarButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed));
+        toolbar.autoSetDimension(.height, toSize: 60);
+
+        let undoButton = UIBarButtonItem(
+            image: UIImage(systemName: "arrow.uturn.backward"),
+            style: .plain,
+            target: self,
+            action: #selector(undoPressed)
+        );
+        undoButton.accessibilityLabel = "Undo";
+
+        let redoButton = UIBarButtonItem(
+            image: UIImage(systemName: "arrow.uturn.forward"),
+            style: .plain,
+            target: self,
+            action: #selector(redoPressed)
+        );
+        redoButton.accessibilityLabel = "Redo";
+
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil);
-        
-        toolbar.items = [cancelBarButton, flexSpace, UIBarButtonItem(customView: titleLabel), flexSpace, doneBarButton];
+
+        toolbar.items = [undoButton, redoButton, flexSpace, UIBarButtonItem(customView: titleLabel)];
         return toolbar;
     }()
-    
+
     lazy var textField: MDCFilledTextField = {
         let textField = MDCFilledTextField(frame: CGRect(x: 0, y: 0, width: 200, height: 100));
         textField.delegate = self;
@@ -65,25 +78,25 @@ class NumberFieldView : BaseFieldView {
         textField.sizeToFit();
         return textField;
     }()
-    
+
     required init(coder aDecoder: NSCoder) {
         fatalError("This class does not support NSCoding")
     }
-    
+
     convenience init(field: [String: Any], editMode: Bool = true, delegate: (ObservationFormFieldListener & FieldSelectionDelegate)? = nil) {
         self.init(field: field, delegate: delegate, value: nil);
     }
-    
+
     init(field: [String: Any], editMode: Bool = true, delegate: (ObservationFormFieldListener & FieldSelectionDelegate)? = nil, value: String?) {
         super.init(field: field, delegate: delegate, value: value, editMode: editMode);
-        
+
         self.min = self.field[FieldKey.min.key] as? NSNumber;
         self.max = self.field[FieldKey.max.key] as? NSNumber;
-        
+
         setupInputView();
         setValue(value);
     }
-    
+
     override func applyTheme(withScheme scheme: MDCContainerScheming?) {
         guard let scheme = scheme else {
             return
@@ -94,7 +107,7 @@ class NumberFieldView : BaseFieldView {
         textField.trailingView?.tintColor = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6);
         textField.tintColor = scheme.colorScheme.onSurfaceColor;
     }
-    
+
     func setupInputView() {
         if (editMode) {
             viewStack.addArrangedSubview(textField);
@@ -104,19 +117,19 @@ class NumberFieldView : BaseFieldView {
             fieldValue.text = getValue()?.stringValue;
         }
     }
-    
+
     override func getValue() -> Any? {
         return number;
     }
-    
+
     func getValue() -> NSNumber? {
         return number;
     }
-    
+
     override func setValue(_ value: Any?) {
         setValue(value as? String);
     }
-    
+
     func setValue(_ value: String?) {
         number = nil;
         if (value != nil) {
@@ -128,44 +141,41 @@ class NumberFieldView : BaseFieldView {
             fieldValue.text = number?.stringValue;
         }
     }
-    
+
     func setTextFieldValue() {
         textField.text = number?.stringValue
     }
-    
-    @objc func doneButtonPressed() {
-        shouldResign = true;
-        textField.resignFirstResponder();
+
+    @objc func undoPressed() {
+        textField.undoManager?.undo();
     }
-    
-    @objc func cancelButtonPressed() {
-        shouldResign = true;
-        setTextFieldValue();
-        textField.resignFirstResponder();
+
+    @objc func redoPressed() {
+        textField.undoManager?.redo();
     }
-    
-    override func isEmpty() -> Bool{
+
+    override func isEmpty() -> Bool {
         if let checkText = textField.text {
             return checkText.count == 0;
         }
         return true;
     }
-    
+
     override func getErrorMessage() -> String {
         if let helperText = helperText {
             return helperText
         }
         return "Must be a number";
     }
-    
+
     override func isValid(enforceRequired: Bool = false) -> Bool {
         return self.isValid(enforceRequired: enforceRequired, number: self.number);
     }
-    
+
     func isValid(enforceRequired: Bool = false, number: NSNumber?) -> Bool {
         return super.isValid(enforceRequired: enforceRequired) && isValidNumber(number);
     }
-    
+
     func isValidNumber(_ number: NSNumber?) -> Bool {
         if (!isEmpty() && number == nil) {
             return false;
@@ -182,7 +192,7 @@ class NumberFieldView : BaseFieldView {
         }
         return true;
     }
-    
+
     override func setValid(_ valid: Bool) {
         super.setValid(valid);
         if (valid) {
@@ -198,11 +208,11 @@ class NumberFieldView : BaseFieldView {
 }
 
 extension NumberFieldView: UITextFieldDelegate {
-    
+
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        return shouldResign;
+        return true;
     }
-    
+
     func textFieldDidEndEditing(_ textField: UITextField) {
         if let text: String = textField.text {
             let number = formatter.number(from: text);
@@ -213,15 +223,14 @@ extension NumberFieldView: UITextFieldDelegate {
             }
             self.number = number;
         }
-        shouldResign = false;
     }
-    
+
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         // allow backspace
         if (string.count == 0) {
             return true;
         }
-        
+
         if let text = textField.text as NSString? {
             let txtAfterUpdate = text.replacingCharacters(in: range, with: string);
             let number = formatter.number(from: txtAfterUpdate);
@@ -231,7 +240,7 @@ extension NumberFieldView: UITextFieldDelegate {
             setValid(isValidNumber(number));
             return true;
         }
-        
+
         return false;
     }
 }

--- a/Mage/ObservationEditCardCollectionViewController.swift
+++ b/Mage/ObservationEditCardCollectionViewController.swift
@@ -135,6 +135,10 @@ import MaterialComponents.MDCCard
             self.title = "Edit Observation";
         }
         
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard));
+        tap.cancelsTouchesInView = false;
+        self.view.addGestureRecognizer(tap);
+
         self.view.addSubview(scrollView)
         addScrollViewConstraints();
         scrollView.addSubview(stackView)
@@ -458,6 +462,10 @@ import MaterialComponents.MDCCard
         }
     }
     
+    @objc func dismissKeyboard() {
+        self.view.endEditing(true);
+    }
+
     @objc func cancel(sender: UIBarButtonItem) {
         self.delegate?.cancelEdit();
     }

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -12,8 +12,7 @@ import MaterialComponents.MDCTextField;
 class TextFieldView : BaseFieldView {
     private var multiline: Bool = false;
     private var keyboardType: UIKeyboardType = .default;
-    private var shouldResign: Bool = false;
-    
+
     lazy var multilineTextField: MDCFilledTextArea  = {
         let multilineTextField = MDCFilledTextArea(frame: CGRect(x: 0, y: 0, width: 200, height: 100));
         multilineTextField.textView.delegate = self;
@@ -34,7 +33,7 @@ class TextFieldView : BaseFieldView {
         multilineTextField.sizeToFit();
         return multilineTextField;
     }()
-    
+
     lazy var textField: MDCFilledTextField = {
         let textField = MDCFilledTextField(frame: CGRect(x: 0, y: 0, width: 200, height: 100));
         textField.delegate = self;
@@ -58,42 +57,57 @@ class TextFieldView : BaseFieldView {
             textField.text = value as? String;
         }
         textField.sizeToFit();
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged);
         return textField;
     }()
-    
+
     private lazy var accessoryView: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 50);
-        
-        let doneBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonPressed));
-        doneBarButton.accessibilityLabel = "Done";
-        let cancelBarButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonPressed));
-        cancelBarButton.accessibilityLabel = "Cancel";
+        toolbar.autoSetDimension(.height, toSize: 60);
+        // Adding undo & redo components
+        let undoButton = UIBarButtonItem(
+            image: UIImage(systemName: "arrow.uturn.backward"),
+            style: .plain,
+            target: self,
+            action: #selector(undoPressed)
+        );
+        undoButton.accessibilityLabel = "Undo";
+
+        let redoButton = UIBarButtonItem(
+            image: UIImage(systemName: "arrow.uturn.forward"),
+            style: .plain,
+            target: self,
+            action: #selector(redoPressed)
+        );
+        redoButton.accessibilityLabel = "Redo";
+
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil);
-        
-        toolbar.items = [cancelBarButton, flexSpace, doneBarButton];
+
+        // New toolbar to host the two buttons
+        toolbar.items = [undoButton, redoButton, flexSpace];
+        toolbar.alpha = 0;
         return toolbar;
     }()
-    
+
     required init(coder aDecoder: NSCoder) {
         fatalError("This class does not support NSCoding")
     }
-    
+
     convenience init(field: [String: Any], editMode: Bool = true, delegate: (ObservationFormFieldListener & FieldSelectionDelegate)? = nil, keyboardType: UIKeyboardType = .default) {
         self.init(field: field, editMode: editMode, delegate: delegate, value: nil, multiline: false, keyboardType: keyboardType);
     }
-    
+
     convenience init(field: [String: Any], editMode: Bool = true, delegate: (ObservationFormFieldListener & FieldSelectionDelegate)? = nil, multiline: Bool, keyboardType: UIKeyboardType = .default) {
         self.init(field: field, editMode: editMode, delegate: delegate, value: nil, multiline: multiline);
     }
-    
+
     init(field: [String: Any], editMode: Bool = true, delegate: (ObservationFormFieldListener & FieldSelectionDelegate)? = nil, value: String?, multiline: Bool = false, keyboardType: UIKeyboardType = .default) {
         super.init(field: field, delegate: delegate, value: value, editMode: editMode);
         self.multiline = multiline;
         self.keyboardType = keyboardType;
         self.addFieldView();
     }
-    
+
     override func updateConstraints() {
         if (!didSetupConstraints) {
             if (editMode) {
@@ -102,13 +116,11 @@ class TextFieldView : BaseFieldView {
                 } else {
                     textField.autoPinEdgesToSuperviewEdges();
                 }
-            } else {
-                
             }
         }
         super.updateConstraints();
     }
-    
+
     override func applyTheme(withScheme scheme: MDCContainerScheming?) {
         guard let scheme = scheme else {
             return
@@ -125,7 +137,7 @@ class TextFieldView : BaseFieldView {
             textField.tintColor = scheme.colorScheme.onSurfaceColor;
         }
     }
-    
+
     func addFieldView() {
         if (editMode) {
             if (multiline) {
@@ -143,11 +155,11 @@ class TextFieldView : BaseFieldView {
             }
         }
     }
-    
+
     override func setValue(_ value: Any?) {
         self.setValue(value as? String);
     }
-    
+
     func setValue(_ value: String?) {
         self.value = value;
         if (self.multiline) {
@@ -156,11 +168,11 @@ class TextFieldView : BaseFieldView {
             self.editMode ? (textField.text = value) : (fieldValue.text = value);
         }
     }
-    
+
     func getValue() -> String? {
         return value as? String;
     }
-    
+
     override func isEmpty() -> Bool {
         if (self.multiline) {
             return (multilineTextField.textView.text ?? "").count == 0;
@@ -168,11 +180,11 @@ class TextFieldView : BaseFieldView {
             return (textField.text ?? "").count == 0;
         }
     }
-    
+
     override func getErrorMessage() -> String {
         return ((field[FieldKey.title.key] as? String) ?? "Field ") + " is required";
     }
-    
+
     override func setValid(_ valid: Bool) {
         super.setValid(valid);
         if (valid) {
@@ -201,32 +213,49 @@ class TextFieldView : BaseFieldView {
 
 extension TextFieldView {
     func resignFieldFirstResponder() {
-        shouldResign = true;
         if (self.multiline) {
             multilineTextField.textView.resignFirstResponder();
         } else {
             textField.resignFirstResponder();
         }
     }
-    
-    @objc func doneButtonPressed() {
-        self.resignFieldFirstResponder();
+
+    @objc func textFieldDidChange() {
+        showAccessoryView();
     }
-    
-    @objc func cancelButtonPressed() {
-        setValue(self.value as? String ?? nil);
-        self.resignFieldFirstResponder();
+
+    func showAccessoryView() {
+        guard accessoryView.alpha == 0 else { return }
+        UIView.animate(withDuration: 0.2) {
+            self.accessoryView.alpha = 1;
+        }
+    }
+
+    @objc func undoPressed() {
+        if multiline {
+            multilineTextField.textView.undoManager?.undo();
+        } else {
+            textField.undoManager?.undo();
+        }
+    }
+
+    @objc func redoPressed() {
+        if multiline {
+            multilineTextField.textView.undoManager?.redo();
+        } else {
+            textField.undoManager?.redo();
+        }
     }
 }
 
 extension TextFieldView: UITextFieldDelegate {
-    
+
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        shouldResign = false;
+        accessoryView.alpha = 0;
     }
-    
+
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        return shouldResign;
+        return true;
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
@@ -238,14 +267,21 @@ extension TextFieldView: UITextFieldDelegate {
             }
             delegate?.fieldValueChanged(field, value: value);
         }
-        shouldResign = false;
     }
 }
 
 extension TextFieldView: UITextViewDelegate {
-    
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        accessoryView.alpha = 0;
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+        showAccessoryView();
+    }
+
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
-        return shouldResign;
+        return true;
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -257,6 +293,5 @@ extension TextFieldView: UITextViewDelegate {
             }
             delegate?.fieldValueChanged(field, value: value);
         }
-        shouldResign = false;
     }
 }

--- a/MageTests/Observation/Fields/NumberFieldViewTests.swift
+++ b/MageTests/Observation/Fields/NumberFieldViewTests.swift
@@ -139,22 +139,22 @@ class NumberFieldViewTests: KIFSpec {
             
             it("set value via input") {
                 let delegate = MockFieldDelegate();
-                
+
                 numberFieldView = NumberFieldView(field: field, delegate: delegate);
                 numberFieldView.applyTheme(withScheme: MAGEScheme.scheme());
-                
+
                 view.addSubview(numberFieldView)
                 numberFieldView.autoPinEdgesToSuperviewEdges();
-                
+
                 expect(numberFieldView.textField.text) == "";
-                
+
                 tester().waitForView(withAccessibilityLabel: field[FieldKey.name.key] as? String);
                 tester().enterText("2", intoViewWithAccessibilityLabel: field[FieldKey.name.key] as? String);
-                tester().tapView(withAccessibilityLabel: "Done");
-                
+                numberFieldView.textField.resignFirstResponder();
+
                 expect(numberFieldView.textField.text) == "2";
                 expect(numberFieldView.fieldNameLabel.text) == "Number Field"
-                
+
                 expect(delegate.fieldChangedCalled).to(beTrue());
             }
             
@@ -481,42 +481,40 @@ class NumberFieldViewTests: KIFSpec {
                 expect(delegate.newValue as? NSNumber) == 5;
             }
             
-            it("allow canceling") {
+            it("editing ended saves new number value") {
                 let delegate = MockFieldDelegate()
                 numberFieldView = NumberFieldView(field: field, delegate: delegate, value: "2");
                 numberFieldView.applyTheme(withScheme: MAGEScheme.scheme());
                 view.addSubview(numberFieldView)
                 numberFieldView.autoPinEdgesToSuperviewEdges();
-                
+
                 numberFieldView.textField.text = "4";
-                numberFieldView.cancelButtonPressed();
-                expect(delegate.fieldChangedCalled) == false;
-                expect(numberFieldView.textField.text) == "2";
-                expect(numberFieldView.getValue()) == 2;
-            }
-            
-            it("done button should change value") {
-                let delegate = MockFieldDelegate()
-                numberFieldView = NumberFieldView(field: field, delegate: delegate, value: "2");
-                numberFieldView.applyTheme(withScheme: MAGEScheme.scheme());
-                view.addSubview(numberFieldView)
-                numberFieldView.autoPinEdgesToSuperviewEdges();
-                numberFieldView.textField.text = "4";
-                numberFieldView.doneButtonPressed();
                 numberFieldView.textFieldDidEndEditing(numberFieldView.textField);
                 expect(delegate.fieldChangedCalled) == true;
                 expect(numberFieldView.textField.text) == "4";
                 expect(numberFieldView.getValue()) == 4;
             }
             
-            it("done button should send nil as new value") {
+            it("editing ended with new value notifies delegate") {
+                let delegate = MockFieldDelegate()
+                numberFieldView = NumberFieldView(field: field, delegate: delegate, value: "2");
+                numberFieldView.applyTheme(withScheme: MAGEScheme.scheme());
+                view.addSubview(numberFieldView)
+                numberFieldView.autoPinEdgesToSuperviewEdges();
+                numberFieldView.textField.text = "4";
+                numberFieldView.textFieldDidEndEditing(numberFieldView.textField);
+                expect(delegate.fieldChangedCalled) == true;
+                expect(numberFieldView.textField.text) == "4";
+                expect(numberFieldView.getValue()) == 4;
+            }
+
+            it("editing ended with empty value sends nil") {
                 let delegate = MockFieldDelegate()
                 numberFieldView = NumberFieldView(field: field, delegate: delegate, value: "2");
                 numberFieldView.applyTheme(withScheme: MAGEScheme.scheme());
                 view.addSubview(numberFieldView)
                 numberFieldView.autoPinEdgesToSuperviewEdges();
                 numberFieldView.textField.text = "";
-                numberFieldView.doneButtonPressed();
                 numberFieldView.textFieldDidEndEditing(numberFieldView.textField);
                 expect(delegate.fieldChangedCalled) == true;
                 expect(numberFieldView.textField.text) == "";

--- a/MageTests/Observation/Fields/TextFieldViewTests.swift
+++ b/MageTests/Observation/Fields/TextFieldViewTests.swift
@@ -146,16 +146,16 @@ class TextFieldViewTests: KIFSpec {
 
                 textFieldView = TextFieldView(field: field, delegate: delegate);
                 textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
-                
+
                 view.addSubview(textFieldView)
                 textFieldView.autoPinEdgesToSuperviewEdges();
-                
+
                 tester().waitForView(withAccessibilityLabel: field["name"] as? String);
                 tester().enterText("new text", intoViewWithAccessibilityLabel: field["name"] as? String);
-                tester().tapView(withAccessibilityLabel: "Done");
-                
+                textFieldView.resignFieldFirstResponder();
+
                 expect(delegate.fieldChangedCalled).to(beTrue());
-                
+
                 expect(textFieldView.textField.placeholder) == "Field Title"
                 expect(textFieldView.textField.text) == "new text";
             }
@@ -218,49 +218,34 @@ class TextFieldViewTests: KIFSpec {
                 expect(delegate.newValue as? String) == "new value";
             }
             
-            it("done button should send nil as new value") {
+            it("editing ended saves nil when text cleared") {
                 let delegate = MockFieldDelegate();
 
                 textFieldView = TextFieldView(field: field, delegate: delegate, value: "old value");
                 textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
                 view.addSubview(textFieldView)
                 textFieldView.autoPinEdgesToSuperviewEdges();
-                
-                textFieldView.textField.text = nil;
-                textFieldView.doneButtonPressed();
+
+                textFieldView.textField.text = "";
                 textFieldView.textFieldDidEndEditing(textFieldView.textField);
                 expect(delegate.fieldChangedCalled).to(beTrue());
                 expect(delegate.newValue).to(beNil());
-                expect(textFieldView.textField.text).to(equal(""));
                 expect(textFieldView.value as? String).to(beNil());
             }
-            
-            it("done button should change text") {
+
+            it("editing ended saves new text value") {
                 textFieldView = TextFieldView(field: field, value: "old value");
                 textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
                 view.addSubview(textFieldView)
                 textFieldView.autoPinEdgesToSuperviewEdges();
-                
+
                 textFieldView.textField.text = "new value";
-                textFieldView.doneButtonPressed();
                 textFieldView.textFieldDidEndEditing(textFieldView.textField);
                 expect(textFieldView.textField.text) == "new value";
                 expect(textFieldView.value as? String) == "new value";
             }
-            
-            it("cancel button should not change text") {
-                textFieldView = TextFieldView(field: field, value: "old value");
-                textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
-                view.addSubview(textFieldView)
-                textFieldView.autoPinEdgesToSuperviewEdges();
-                
-                textFieldView.textField.text = "new value";
-                textFieldView.cancelButtonPressed();
-                expect(textFieldView.textField.text) == "old value";
-                expect(textFieldView.value as? String) == "old value";
-            }
         }
-        
+
         describe("TextFieldView Multi Line") {
             
             var textFieldView: TextFieldView!
@@ -397,20 +382,20 @@ class TextFieldViewTests: KIFSpec {
             
             it("set value via input") {
                 let delegate = MockFieldDelegate();
-                
+
                 textFieldView = TextFieldView(field: field, delegate: delegate, multiline: true);
                 textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
-                
+
                 view.addSubview(textFieldView)
                 textFieldView.autoPinEdgesToSuperviewEdges();
                 expect(textFieldView.multilineTextField.textView.text) == "";
-                
+
                 tester().waitForView(withAccessibilityLabel: field["name"] as? String);
                 tester().enterText("new\ntext", intoViewWithAccessibilityLabel: field["name"] as? String);
-                tester().tapView(withAccessibilityLabel: "Done");
-                
+                textFieldView.resignFieldFirstResponder();
+
                 expect(delegate.fieldChangedCalled).to(beTrue());
-                
+
                 expect(textFieldView.multilineTextField.textView.text) == "new\ntext";
                 expect(textFieldView.multilineTextField.placeholder) == "Multi Line Field Title"
             }
@@ -472,46 +457,31 @@ class TextFieldViewTests: KIFSpec {
                 expect(delegate.newValue as? String) == "this is a new value";
             }
             
-            it("done button should send nil as new value") {
+            it("editing ended saves nil when text cleared") {
                 let delegate = MockFieldDelegate();
-                
-                textFieldView = TextFieldView(field: field, delegate: delegate, value: "old value");
+
+                textFieldView = TextFieldView(field: field, delegate: delegate, value: "old value", multiline: true);
                 textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
                 view.addSubview(textFieldView)
                 textFieldView.autoPinEdgesToSuperviewEdges();
-                
-                textFieldView.multilineTextField.textView.text = nil;
-                textFieldView.doneButtonPressed();
+
+                textFieldView.multilineTextField.textView.text = "";
                 textFieldView.textViewDidEndEditing(textFieldView.multilineTextField.textView);
                 expect(delegate.fieldChangedCalled).to(beTrue());
                 expect(delegate.newValue).to(beNil());
-                expect(textFieldView.multilineTextField.textView.text).to(equal(""));
                 expect(textFieldView.value as? String).to(beNil());
             }
-            
-            it("done button should change text") {
+
+            it("editing ended saves new text value") {
                 textFieldView = TextFieldView(field: field, value: "old value", multiline: true);
                 textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
                 view.addSubview(textFieldView)
                 textFieldView.autoPinEdgesToSuperviewEdges();
-                
+
                 textFieldView.multilineTextField.textView.text = "new value";
-                textFieldView.doneButtonPressed();
                 textFieldView.textViewDidEndEditing(textFieldView.multilineTextField.textView);
                 expect(textFieldView.multilineTextField.textView.text) == "new value";
                 expect(textFieldView.value as? String) == "new value";
-            }
-            
-            it("cancel button should not change text") {
-                textFieldView = TextFieldView(field: field, value: "old value", multiline: true);
-                textFieldView.applyTheme(withScheme: MAGEScheme.scheme());
-                view.addSubview(textFieldView)
-                textFieldView.autoPinEdgesToSuperviewEdges();
-                
-                textFieldView.multilineTextField.textView.text = "new value";
-                textFieldView.cancelButtonPressed();
-                expect(textFieldView.multilineTextField.textView.text) == "old value";
-                expect(textFieldView.value as? String) == "old value";
             }
         }
     }


### PR DESCRIPTION
Removing "X" and "checkmark" for text-field inputs, replacing with undo/redo capability and ability to leave by clicking out of box