### PR TITLE
fix: core data crash associating user to observation on wrong thread

### DIFF
--- a/Mage/CoreData/Observation.swift
+++ b/Mage/CoreData/Observation.swift
@@ -726,7 +726,11 @@ enum State: Int, CustomStringConvertible {
                             
                             let fetchUserTask = User.operationToFetchUser(userId: userId) { task, response in
                                 NSLog("Fetched user \(userId) successfully.")
-                                observation.user = User.mr_findFirst(byAttribute: ObservationKey.remoteId.key, withValue: userId, in: context)
+                                context.perform {
+                                    let localObservation = observation.mr_(in: context)
+                                    let user = User.mr_findFirst(byAttribute: ObservationKey.remoteId.key, withValue: userId, in: context)
+                                    localObservation?.user = user
+                                }
                             } failure: { task, error in
                                 NSLog("Failed to fetch user \(userId) error \(error)")
                             }


### PR DESCRIPTION
This PR fixes a crash during the initial load after login.  Associating a user managed object to an observation managed object on the wrong thread after fetching the user record from the server asynchronously was causing the crash.