### PR TITLE
'Save' & 'X' fix - Number field match to text field

### DIFF
--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -61,7 +61,8 @@ class NumberFieldView : BaseFieldView {
 
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil);
 
-        toolbar.items = [undoButton, redoButton, flexSpace, UIBarButtonItem(customView: titleLabel)];
+        toolbar.items = [undoButton, redoButton, flexSpace];
+        toolbar.alpha = 0;
         return toolbar;
     }()
 
@@ -76,6 +77,7 @@ class NumberFieldView : BaseFieldView {
         textField.keyboardType = .decimalPad;
         setPlaceholder(textField: textField);
         textField.sizeToFit();
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged);
         return textField;
     }()
 
@@ -207,7 +209,24 @@ class NumberFieldView : BaseFieldView {
     }
 }
 
+extension NumberFieldView {
+    @objc func textFieldDidChange() {
+        showAccessoryView();
+    }
+
+    func showAccessoryView() {
+        guard accessoryView.alpha == 0 else { return }
+        UIView.animate(withDuration: 0.2) {
+            self.accessoryView.alpha = 1;
+        }
+    }
+}
+
 extension NumberFieldView: UITextFieldDelegate {
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        accessoryView.alpha = 0;
+    }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         return true;

--- a/Mage/ObservationEditCardCollectionViewController.swift
+++ b/Mage/ObservationEditCardCollectionViewController.swift
@@ -156,8 +156,6 @@ import MaterialComponents.MDCCard
             }
             switch animation {
             case .keyboardWillShow:
-                self.navigationItem.rightBarButtonItem?.isEnabled = false;
-                self.navigationItem.leftBarButtonItem?.isEnabled = false;
                 self.bottomConstraint?.constant = -keyboardFrame.height;
                 self.view.layoutIfNeeded();
 
@@ -471,6 +469,7 @@ import MaterialComponents.MDCCard
     }
     
     @objc func saveObservation(sender: UIBarButtonItem) {
+        self.view.endEditing(true);
         removeDeletedForms();
         guard let observation = self.observation else { return }
         if (checkObservationValidity()) {


### PR DESCRIPTION
- Allowed use of form 'Save' and 'X' buttons while in text/number fields
- Added undo/redo styling for number fields to match text fields