### PR TITLE
Introduce persistence framework abstraction layer

### DIFF
--- a/MAGE.xcodeproj/project.pbxproj
+++ b/MAGE.xcodeproj/project.pbxproj
@@ -325,6 +325,8 @@
 		F767AC7927D95802005684E5 /* Role+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72D42952694B60300F9AC3B /* Role+CoreDataProperties.swift */; };
 		F767AC7A27D95811005684E5 /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72D427F2694B60300F9AC3B /* Team.swift */; };
 		F76949161AA6436000CB680B /* EventChooserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76949151AA6436000CB680B /* EventChooserController.swift */; };
+		F76A02742FE49D0300CDBA4F /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = F76A02732FE49D0300CDBA4F /* Persistence */; };
+		F76A02772FE49F4400CDBA4F /* MagicalRecordPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76A02762FE49F4400CDBA4F /* MagicalRecordPersistence.swift */; };
 		F76A15BF1A93C35400F2BDF1 /* KeyboardConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = F76A15BE1A93C35400F2BDF1 /* KeyboardConstraint.m */; };
 		F76A15C21A93F56300F2BDF1 /* UIResponder+FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = F76A15C11A93F56300F2BDF1 /* UIResponder+FirstResponder.m */; };
 		F76A15C41A9402A400F2BDF1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F76A15C31A9402A400F2BDF1 /* LaunchScreen.storyboard */; };
@@ -1043,6 +1045,8 @@
 		F7614DA92006902000676366 /* apiSuccess.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = apiSuccess.json; path = responses/apiSuccess.json; sourceTree = SOURCE_ROOT; };
 		F7641CE3276D423A006225BA /* CanCreateObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanCreateObservation.swift; sourceTree = "<group>"; };
 		F76949151AA6436000CB680B /* EventChooserController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventChooserController.swift; sourceTree = "<group>"; };
+		F76A02722FE49CAB00CDBA4F /* Persistence */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Persistence; sourceTree = "<group>"; };
+		F76A02762FE49F4400CDBA4F /* MagicalRecordPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicalRecordPersistence.swift; sourceTree = "<group>"; };
 		F76A15BD1A93C35400F2BDF1 /* KeyboardConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyboardConstraint.h; sourceTree = "<group>"; };
 		F76A15BE1A93C35400F2BDF1 /* KeyboardConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeyboardConstraint.m; sourceTree = "<group>"; };
 		F76A15C01A93F56300F2BDF1 /* UIResponder+FirstResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIResponder+FirstResponder.h"; sourceTree = "<group>"; };
@@ -1383,6 +1387,7 @@
 				F76FAE861A5C797400BD8443 /* CoreAudio.framework in Frameworks */,
 				F70EAF3D199D052D00909C8A /* MediaPlayer.framework in Frameworks */,
 				4C390F4A197DB7B000AB3CCB /* MessageUI.framework in Frameworks */,
+				F76A02742FE49D0300CDBA4F /* Persistence in Frameworks */,
 				F7A94DA118ADBD5400CB9EE0 /* MapKit.framework in Frameworks */,
 				F7E066892FC9CFE1008C876C /* GeoPackage in Frameworks */,
 				F7A94DAB18B5100B00CB9EE0 /* QuartzCore.framework in Frameworks */,
@@ -2277,6 +2282,14 @@
 			name = Event;
 			sourceTree = "<group>";
 		};
+		F76A02752FE49F2B00CDBA4F /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				F76A02762FE49F4400CDBA4F /* MagicalRecordPersistence.swift */,
+			);
+			path = Persistence;
+			sourceTree = "<group>";
+		};
 		F76A15BC1A93C33300F2BDF1 /* Constraints */ = {
 			isa = PBXGroup;
 			children = (
@@ -2473,6 +2486,7 @@
 		F7A94D5D18AD9CAF00CB9EE0 = {
 			isa = PBXGroup;
 			children = (
+				F76A02722FE49CAB00CDBA4F /* Persistence */,
 				F76B4A6F28E61E710012BF4F /* CHANGELOG.md */,
 				F72D422B2694B60300F9AC3B /* sdk */,
 				F7A94D7118AD9CB000CB9EE0 /* Mage */,
@@ -2522,6 +2536,7 @@
 		F7A94D7118AD9CB000CB9EE0 /* Mage */ = {
 			isa = PBXGroup;
 			children = (
+				F76A02752FE49F2B00CDBA4F /* Persistence */,
 				2FAE23FB2B5596A900629721 /* Search */,
 				F7A94D7A18AD9CB000CB9EE0 /* AppDelegate.h */,
 				F7A94D7B18AD9CB000CB9EE0 /* AppDelegate.m */,
@@ -3567,6 +3582,7 @@
 				F73607E026F91CEB008CF824 /* GeoPackageFeatureBottomSheetView.swift in Sources */,
 				F743008C254775AB00DCE050 /* SplitLayout.swift in Sources */,
 				F7EBAEBC27615E5600650F4F /* MapMixin.swift in Sources */,
+				F76A02772FE49F4400CDBA4F /* MagicalRecordPersistence.swift in Sources */,
 				F7098F2E24980DD000313703 /* FeedItemRetriever.swift in Sources */,
 				F72D43302694B60300F9AC3B /* ObservationFavorite+CoreDataProperties.swift in Sources */,
 				F72D42F22694B60300F9AC3B /* SessionTaskQueue.m in Sources */,
@@ -4169,6 +4185,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F7E0309F2FC9D2BF0042A671 /* XCRemoteSwiftPackageReference "mgrs-ios" */;
 			productName = MGRS;
+		};
+		F76A02732FE49D0300CDBA4F /* Persistence */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Persistence;
 		};
 		F7E0309D2FC9D2B00042A671 /* GARS */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mage/AppDelegate.m
+++ b/Mage/AppDelegate.m
@@ -20,6 +20,7 @@
 #import "MageConstants.h"
 #import "MAGE-Swift.h"
 #import "GeoPackageImporter.h"
+@import Persistence;
 
 @interface AppDelegate () <UNUserNotificationCenterDelegate>
 @property (nonatomic, strong) TransitionViewController *splashView;
@@ -46,7 +47,6 @@
             self.splashView = nil;
         }
         [self setupMageApplication:application];
-        [self startMageApp];
     }
 }
 
@@ -64,7 +64,6 @@
     
     if (protectedDataAvailable) {
         [self setupMageApplication:application];
-        [self startMageApp];
     }
 
 	return YES;
@@ -80,7 +79,9 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(geoPackageDownloaded:) name:Layer.GeoPackageDownloaded object:nil];
     
     [MageInitializer initializePreferences];
-    [MageInitializer setupCoreData];
+    [MageInitializer setupPersistenceWithCompletionHandler:^{
+        [self startMageApp];
+    }];
 }
 
 - (void) geoPackageDownloaded: (NSNotification *) notification {
@@ -134,26 +135,29 @@
 
 - (void) startMageApp {
     __weak typeof(self) weakSelf = self;
-
+    
     // do a canary save
-    [MagicalRecord saveWithBlock:^(NSManagedObjectContext * _Nonnull localContext) {
-        Canary *canary = [Canary MR_findFirstInContext:localContext];
+    [ObjCCoreDataPersistence write:^PersistenceResult * _Nullable(NSManagedObjectContext * _Nonnull localContext) {
+        Canary *canary = [Canary findFirstInContext:localContext];
         if (!canary) {
-            canary = [Canary MR_createEntityInContext:localContext];
+            canary = [Canary createEntityInContext:localContext];
         }
         canary.launchDate = [NSDate date];
         NSLog(@"startMageApp Canary launch date %@", canary.launchDate);
-    } completion:^(BOOL contextDidSave, NSError * _Nullable error) {
-        NSLog(@"startMageApp canary save success? %d with error %@", contextDidSave, error);
+        return nil;
+    } completion:^(PersistenceResult * _Nonnull result) {
+        NSLog(@"startMageApp canary save success? %d with error %@",
+              result.success,
+              result.persistenceError);
         // error should be null and contextDidSave should be true
-        if (contextDidSave && error == NULL) {
+        if (result.success && result.persistenceError == NULL) {
             self.appCoordinator = [[MageAppCoordinator alloc] initWithNavigationController:self.rootViewController forApplication:self.application andScheme:[MAGEScheme scheme]];
             [self.appCoordinator start];
             [self.gpImporter processOfflineMapArchives];
         } else {
-            NSLog(@"Could not read or write from the database %@", error);
+            NSLog(@"Could not read or write from the database %@", result.persistenceError);
             UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Device Problem"
-                                                                           message:[NSString stringWithFormat:@"An error has occurred on your device that is preventing MAGE from operating correctly. %@", error.localizedDescription]
+                                                                           message:[NSString stringWithFormat:@"An error has occurred on your device that is preventing MAGE from operating correctly. %@", result.persistenceError.localizedDescription]
                                                                     preferredStyle:UIAlertControllerStyleAlert];
             
             [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
@@ -242,14 +246,17 @@
     
     if (protectedDataAvailable) {
         // do a canary save
-        [MagicalRecord saveWithBlock:^(NSManagedObjectContext * _Nonnull localContext) {
-            Canary *canary = [Canary MR_findFirstInContext:localContext];
+        [ObjCCoreDataPersistence write:^PersistenceResult * _Nullable(NSManagedObjectContext * _Nonnull localContext) {
+            Canary *canary = [Canary findFirstInContext:localContext];
             if (!canary) {
-                canary = [Canary MR_createEntityInContext:localContext];
+                canary = [Canary createEntityInContext:localContext];
             }
             canary.launchDate = [NSDate date];
-            NSLog(@"applicationDidBecomeActive Canary launch date %@", canary.launchDate);
-        } completion:^(BOOL contextDidSave, NSError * _Nullable error) {
+            NSLog(@"startMageApp Canary launch date %@", canary.launchDate);
+            return nil;
+        } completion:^(PersistenceResult * _Nonnull result) {
+            BOOL contextDidSave = result.success;
+            NSError *error = result.persistenceError;
             NSLog(@"applicationDidBecomeActive canary save success? %d with error %@", contextDidSave, error);
             // error should be null and contextDidSave should be true
             if (error == NULL) {

--- a/Mage/MageInitializer.swift
+++ b/Mage/MageInitializer.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Persistence
 
 @objc class MageInitializer: NSObject {
     
@@ -25,14 +26,22 @@ import Foundation
         UserDefaults.standard.register(defaults: allPreferences)
     }
     
-    @objc public static func setupCoreData() {
-        MagicalRecord.setupMageCoreDataStack();
-        MagicalRecord.setLoggingLevel(.verbose);
-    }
-
-    @objc public static func clearAndSetupCoreData() {
-        MagicalRecord.deleteAndSetupMageCoreDataStack();
-        MagicalRecord.setLoggingLevel(.verbose);
+    @objc public static func setupPersistence() async {
+        guard let modelURL = Bundle.main.url(forResource: "mage-ios-sdk", withExtension: "momd") else {
+            print("Bundle.main = \(Bundle.main.bundleURL)")
+            
+            if let resourcePath = Bundle.main.resourcePath {
+                let contents = try? FileManager.default.contentsOfDirectory(atPath: resourcePath)
+                print(contents ?? [])
+            }
+            
+            print("mom:", Bundle.main.urls(forResourcesWithExtension: "mom", subdirectory: nil) ?? [])
+            print("momd:", Bundle.main.urls(forResourcesWithExtension: "momd", subdirectory: nil) ?? [])
+            fatalError("Core Data model not found")
+        }
+        let persistence = MagicalRecordPersistence()
+        
+        PersistenceContainer.shared.configure(persistence)
     }
     
     @discardableResult

--- a/Mage/Persistence/MagicalRecordPersistence.swift
+++ b/Mage/Persistence/MagicalRecordPersistence.swift
@@ -1,0 +1,113 @@
+//
+//  MagicalRecordPersistence.swift
+//  MAGE
+//
+//  Created by Daniel Barela on 6/18/26.
+//  Copyright © 2026 National Geospatial Intelligence Agency. All rights reserved.
+//
+
+import Foundation
+import Persistence
+import MagicalRecord
+
+public final class MagicalRecordPersistence: PersistenceProtocol {
+
+    public let viewContext: NSManagedObjectContext
+    public let writeContext: NSManagedObjectContext
+//    let persistentContainer: NSPersistentContainer
+    
+    public init() {
+        MagicalRecord.setupMageCoreDataStack()
+        MagicalRecord.setLoggingLevel(.verbose);
+        viewContext = NSManagedObjectContext.mr_default()
+        writeContext = NSManagedObjectContext.mr_rootSaving()
+    }
+    
+    public func readSync<T>(
+        _ block: @escaping @Sendable (NSManagedObjectContext) -> T
+    ) -> T {
+        return viewContext.performAndWait {
+            block(viewContext)
+        }
+    }
+
+    public func read<T>(
+        _ block: @escaping @Sendable (NSManagedObjectContext) throws -> T
+    ) async rethrows -> T where T : Sendable {
+        let context = viewContext
+        
+        return try await context.perform {
+            try block(context)
+        }
+    }
+
+    public func write<T>(
+        _ block: @escaping @Sendable (NSManagedObjectContext) throws -> T?
+    ) async throws -> PersistenceResult where T : Sendable {
+        await withCheckedContinuation { continuation in
+            var blockError: Error?
+            var blockReturn: Sendable?
+            MagicalRecord.save { context in
+                do {
+                    blockReturn = try block(context)
+                } catch {
+                    blockError = error
+                }
+            } completion: { contextDidSave, error in
+                continuation.resume(
+                    returning: PersistenceResult(
+                        success: contextDidSave,
+                        persistenceError: error as? NSError,
+                        blockReturn: blockReturn,
+                        blockError: blockError as? NSError
+                    )
+                )
+            }
+        }
+    }
+
+    public func background<T>(
+        name: String?,
+        _ block: @escaping @Sendable (NSManagedObjectContext) throws -> T
+    ) async rethrows -> PersistenceResult where T : Sendable {
+        await withCheckedContinuation { continuation in
+            var blockError: Error?
+            var blockReturn: Sendable?
+            MagicalRecord.save { context in
+                context.name = name
+                do {
+                    blockReturn = try block(context)
+                } catch {
+                    blockError = error
+                }
+            } completion: { contextDidSave, error in
+                continuation.resume(
+                    returning: PersistenceResult(
+                        success: contextDidSave,
+                        persistenceError: error as? NSError,
+                        blockReturn: blockReturn,
+                        blockError: blockError as? NSError
+                    )
+                )
+            }
+        }
+    }
+    
+    public func fetchAllSortedBy<T: NSManagedObject>(
+        sortTerm: String,
+        ascending: Bool,
+        predicate: NSPredicate?,
+        groupBy: String?,
+        delegate: NSFetchedResultsControllerDelegate?
+    ) async -> NSFetchedResultsController<T>
+    where T: NSManagedObject & Sendable {
+        T.mr_fetchAllSorted(
+                by: sortTerm,
+                ascending: ascending,
+                with: predicate,
+                groupBy: groupBy,
+                delegate: delegate,
+                in: viewContext
+            ) as! NSFetchedResultsController<T>
+    }
+}

--- a/MageTests/TestingAppDelegate.m
+++ b/MageTests/TestingAppDelegate.m
@@ -45,7 +45,9 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [MageInitializer initializePreferences];
     
-    [MageInitializer setupCoreData];
+    [MageInitializer setupPersistenceWithCompletionHandler:^{
+        
+    }];
 //    [MagicalRecord setupCoreDataStackWithInMemoryStore];
 //    [MagicalRecord setLoggingLevel:MagicalRecordLoggingLevelVerbose];
     

--- a/Persistence/.gitignore
+++ b/Persistence/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Persistence/Package.swift
+++ b/Persistence/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Persistence",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "Persistence",
+            targets: ["Persistence"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "Persistence",
+            swiftSettings: [
+                .treatAllWarnings(as: .error)
+            ]
+        ),
+        .testTarget(
+            name: "PersistenceTests",
+            dependencies: ["Persistence"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Persistence/Sources/Persistence/ManagedObjectModelRegistry.swift
+++ b/Persistence/Sources/Persistence/ManagedObjectModelRegistry.swift
@@ -1,0 +1,27 @@
+//
+//  ManagedObjectModelRegistry.swift
+//  Persistence
+//
+//  Created by Daniel Barela on 6/18/26.
+//
+
+import CoreData
+
+public actor ManagedObjectModelRegistry {
+    public static let shared = ManagedObjectModelRegistry()
+
+    private var cache: [URL: NSManagedObjectModel] = [:]
+
+    public func model(at url: URL) -> NSManagedObjectModel {
+        if let cached = cache[url] {
+            return cached
+        }
+
+        guard let model = NSManagedObjectModel(contentsOf: url) else {
+            fatalError("Unable to load model")
+        }
+
+        cache[url] = model
+        return model
+    }
+}

--- a/Persistence/Sources/Persistence/NSManagedObjectContextExtensions.swift
+++ b/Persistence/Sources/Persistence/NSManagedObjectContextExtensions.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  Persistence
+//
+//  Created by Daniel Barela on 6/19/26.
+//
+
+import Foundation
+import CoreData
+
+public extension NSManagedObjectContext {
+    func fetchFirst <T: NSManagedObject>(_ entityClass: T.Type,
+                                         sortBy: [NSSortDescriptor]? = nil,
+                                         predicate: NSPredicate? = nil) throws -> T? {
+        let result = try self.fetchObjects(entityClass, sortBy: sortBy, fetchLimit: 1, predicate: predicate)
+        return result?.first
+    }
+    
+    func fetchObjects <T: NSManagedObject>(_ entityClass: T.Type,
+                                           sortBy: [NSSortDescriptor]? = nil,
+                                           fetchLimit: Int? = nil,
+                                           predicate: NSPredicate? = nil) throws -> [T]? {
+        guard let request: NSFetchRequest<T> = entityClass.fetchRequest() as? NSFetchRequest<T> else {
+            return nil
+        }
+        if let fetchLimit = fetchLimit {
+            request.fetchLimit = fetchLimit
+        }
+        request.predicate = predicate
+        request.sortDescriptors = sortBy
+        let fetchedResult = try self.fetch(request)
+        return fetchedResult
+    }
+    
+    func fetchFirst<T: NSManagedObject>(_ entityClass: T.Type,
+                                        key: String,
+                                        value: String) -> T? {
+        let predicate = NSPredicate(format: "%K = %@", key, value)
+        return try? self.fetchFirst(
+            entityClass,
+            sortBy: [NSSortDescriptor(key: key, ascending: true)],
+            predicate: predicate
+        )
+    }
+}

--- a/Persistence/Sources/Persistence/NSManagedObjectExtensions.swift
+++ b/Persistence/Sources/Persistence/NSManagedObjectExtensions.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  Persistence
+//
+//  Created by Daniel Barela on 6/19/26.
+//
+
+import Foundation
+import CoreData
+
+public extension NSManagedObject {
+    @objc
+    static func findFirst(inContext: NSManagedObjectContext) -> Self? {
+        do {
+            return try inContext.fetchFirst(
+                Self.self,
+                sortBy: nil,
+                predicate: nil
+            )
+        } catch {
+            return nil
+        }
+    }
+    
+    @objc
+    static func findFirst(with: NSPredicate? = nil, sortedBy: [NSSortDescriptor]? = nil, in context: NSManagedObjectContext) -> Self? {
+        do {
+            return try context.fetchFirst(
+                Self.self,
+                sortBy: sortedBy,
+                predicate: with
+            )
+        } catch {
+            return nil
+        }
+    }
+    
+    @objc
+    static func createEntity(inContext: NSManagedObjectContext) -> Self {
+        let e = Self.init(context: inContext)
+        try? inContext.obtainPermanentIDs(for: [e])
+        return e
+    }
+}

--- a/Persistence/Sources/Persistence/ObjCCoreDataPersistence.swift
+++ b/Persistence/Sources/Persistence/ObjCCoreDataPersistence.swift
@@ -1,0 +1,85 @@
+//
+//  ObjCCoreDataPersistence.swift
+//  Persistence
+//
+//  Created by Daniel Barela on 6/19/26.
+//
+
+import Foundation
+import CoreData
+
+@objc
+public final class ObjCCoreDataPersistence: NSObject, @unchecked Sendable {
+    
+    @objc
+    public static func write(
+        _ block: @Sendable @escaping (NSManagedObjectContext) -> PersistenceResult?,
+        completion: @Sendable @escaping (PersistenceResult) -> Void
+    ) {
+        let persistence = PersistenceContainer.shared.get()
+        
+        Task {
+            let wrapped = ObjCWriteBlock(block)
+            do {
+                let result = try await persistence.write { context in
+                    try wrapped.block(context)
+                }
+                
+                DispatchQueue.main.async {
+                    completion(result)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(
+                        PersistenceResult(success: false, persistenceError: error as NSError)
+                    )
+                }
+            }
+        }
+    }
+    
+    @available(*, deprecated, message: "Returning non sendable is deprecated")
+    @objc
+    public static func syncRead(
+        _ block: @escaping (NSManagedObjectContext) -> Any?
+    ) -> Any? {
+        let persistence = PersistenceContainer.shared.get()
+        let block = block
+        do {
+            let wrapped = ObjCReadBlockAny(block)
+            let viewContext = persistence.viewContext
+            let result = try viewContext.performAndWait{
+                try wrapped.block(viewContext)
+            }
+            return result
+        } catch {
+            return nil
+        }
+    }
+    
+}
+
+private final class ObjCWriteBlock: @unchecked Sendable {
+    let block: (NSManagedObjectContext) throws -> PersistenceResult?
+    
+    init(_ block: @Sendable @escaping (NSManagedObjectContext) throws -> PersistenceResult?) {
+        self.block = block
+    }
+}
+
+private final class ObjCReadBlock: @unchecked Sendable {
+    let block: @Sendable (NSManagedObjectContext) throws -> Sendable?
+    
+    init(_ block: @Sendable @escaping (NSManagedObjectContext) throws -> Sendable?) {
+        self.block = block
+    }
+}
+
+@available(*, deprecated, message: "Returning non sendable is deprecated")
+private final class ObjCReadBlockAny: @unchecked Sendable {
+    let block: (NSManagedObjectContext) throws -> Any?
+    
+    init(_ block: @escaping (NSManagedObjectContext) throws -> Any?) {
+        self.block = block
+    }
+}

--- a/Persistence/Sources/Persistence/Persistence.swift
+++ b/Persistence/Sources/Persistence/Persistence.swift
@@ -1,0 +1,9 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+import Foundation
+import os
+
+public enum PersistentPackage {
+    public static let logger = Logger(subsystem: "Persistence", category: "Persistence")
+}

--- a/Persistence/Sources/Persistence/PersistenceContainer.swift
+++ b/Persistence/Sources/Persistence/PersistenceContainer.swift
@@ -1,0 +1,31 @@
+//
+//  PersistenceContainer.swift
+//  Persistence
+//
+//  Created by Daniel Barela on 6/19/26.
+//
+
+import Foundation
+
+public final class PersistenceContainer: NSObject, @unchecked Sendable {
+    public static let shared = PersistenceContainer()
+    
+    private var persistence: PersistenceProtocol?
+    
+    private let lock = NSLock()
+    
+    public func configure(_ persistence: PersistenceProtocol) {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        precondition(self.persistence == nil)
+        self.persistence = persistence
+    }
+    
+    public func get() -> PersistenceProtocol {
+        guard let persistence else {
+            fatalError("Not configured")
+        }
+        return persistence
+    }
+}

--- a/Persistence/Sources/Persistence/PersistenceProtocol.swift
+++ b/Persistence/Sources/Persistence/PersistenceProtocol.swift
@@ -1,0 +1,58 @@
+//
+//  PersistenceProtocol.swift
+//  Persistence
+//
+//  Created by Daniel Barela on 6/18/26.
+//
+
+@preconcurrency import CoreData
+
+public enum StorageType {
+    case persistent, inMemory
+}
+
+public enum PersistenceError: Error {
+    case modelNotFound
+}
+
+@objc
+public final class PersistenceResult: NSObject, Sendable {
+    @objc public let success: Bool
+    @objc public let persistenceError: NSError?
+    @objc public let blockError: NSError?
+    @objc public let blockReturn: Sendable?
+    
+    @objc
+    public init(success: Bool = true, persistenceError: NSError? = nil, blockReturn: Sendable? = nil, blockError: NSError? = nil) {
+        self.success = success
+        self.persistenceError = persistenceError
+        self.blockReturn = blockReturn
+        self.blockError = blockError
+    }
+}
+
+public protocol PersistenceProtocol: Sendable {
+    var viewContext: NSManagedObjectContext { get }
+    var writeContext: NSManagedObjectContext { get }
+    
+    func read<T: Sendable>(
+        _ block: @escaping @Sendable (NSManagedObjectContext) throws -> T
+    ) async rethrows -> T
+    func write<T: Sendable>(
+        _ block: @escaping @Sendable (NSManagedObjectContext) throws -> T?
+    ) async throws -> PersistenceResult
+    func background<T: Sendable>(
+        name: String?,
+        _ block: @escaping @Sendable (NSManagedObjectContext) throws -> T
+    ) async rethrows -> PersistenceResult
+    
+    func fetchAllSortedBy<T: NSManagedObject>(
+        sortTerm: String,
+        ascending: Bool,
+        predicate: NSPredicate?,
+        groupBy: String?,
+        delegate: NSFetchedResultsControllerDelegate?
+    ) async -> NSFetchedResultsController<T>
+    where T: NSManagedObject & Sendable
+
+}

--- a/Persistence/Tests/PersistenceTests/PersistenceTests.swift
+++ b/Persistence/Tests/PersistenceTests/PersistenceTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import Persistence
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}


### PR DESCRIPTION
# Introduce persistence framework abstraction layer

## Summary

This change introduces the initial persistence framework required to migrate MAGE away from direct Magical Record usage while preserving existing Core Data behavior.

A new `Persistence` Swift package defines a persistence abstraction layer, including a `PersistenceProtocol`, shared persistence container, Core Data convenience extensions, and Objective-C bridging APIs. The initial implementation continues to use Magical Record internally through `MagicalRecordPersistence`, allowing migration to happen incrementally without requiring a full rewrite of existing persistence code.

The application startup flow has been updated to initialize the new persistence container before launching the application, and existing Core Data usage has been routed through the new persistence APIs.

## What Changed

### New Persistence Swift Package

Added a new `Persistence` package containing:

- `PersistenceProtocol`
  - Defines async read/write/background persistence operations
  - Provides a future abstraction point for alternate persistence implementations

- `PersistenceContainer`
  - Provides application-wide persistence dependency injection
  - Allows the underlying persistence implementation to be swapped independently of consumers

- `PersistenceResult`
  - Standardizes persistence operation results and error reporting

- Core Data utilities:
  - `NSManagedObjectContext` fetch helpers
  - `NSManagedObject` creation and lookup helpers
  - Managed object model registry

### Magical Record Migration Adapter

Added `MagicalRecordPersistence` as the first `PersistenceProtocol` implementation.

This adapter:

- Initializes the existing Magical Record stack
- Provides async wrappers around existing Core Data operations
- Bridges Swift concurrency APIs into the existing Objective-C application code
- Allows existing entities to continue using Core Data while consumers migrate gradually

### Objective-C Compatibility Layer

Added `ObjCCoreDataPersistence` to allow existing Objective-C code to interact with the new persistence abstraction.

Updated existing startup canary writes to use:

- `ObjCCoreDataPersistence.write`
- New `PersistenceResult` handling

instead of directly calling Magical Record APIs.

### Application Initialization Changes

Updated application startup:

- Replaced direct `MagicalRecord.setupMageCoreDataStack()` calls
- Added persistence initialization through `MageInitializer`
- Ensured the app starts only after persistence has been configured

### Project Integration

Updated Xcode project configuration to:

- Add the new Persistence Swift package
- Link the package into the application target
- Include the new Magical Record adapter

## Migration Strategy

This change intentionally keeps Magical Record as the backing implementation.

Future migrations can now happen incrementally:

1. Move consumers from Magical Record APIs to `PersistenceProtocol`
2. Introduce a native `NSPersistentContainer` implementation
3. Remove Magical Record dependencies once all callers have migrated

## Testing

Added initial Swift Testing target for the Persistence package.

Existing application behavior remains backed by Magical Record while exercising the new persistence entry points.

## Follow-up Work

Potential follow-up work:

- Replace the shared singleton-style `PersistenceContainer` with the existing dependency injection system
- Add a native `NSPersistentContainer` implementation
- Expand persistence tests around read/write/background operations
- Remove remaining direct Magical Record usage

## Reviewer Notes

A few areas worth reviewing:

- `PersistenceContainer.shared` is currently a singleton-style container. This is intentional for the migration phase but may eventually move into application dependency injection.
- `MagicalRecordPersistence` currently owns Magical Record initialization. This keeps migration incremental but couples the adapter to the current lifecycle.
- `@unchecked Sendable` is used around Core Data and Objective-C bridging. The thread-safety assumptions should remain documented as the abstraction evolves.