### PR TITLE
fix: undo/redo buttons did not appear when re-selecting box until typing started

### DIFF
--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -201,6 +201,7 @@ class NumberFieldView : BaseFieldView {
             textField.leadingAssistiveLabel.text = helperText;
             if let scheme = scheme {
                 textField.applyTheme(withScheme: scheme);
+                textField.tintColor = scheme.colorScheme.onSurfaceColor;
             }
         } else {
             textField.applyErrorTheme(withScheme: globalErrorContainerScheme());
@@ -225,7 +226,9 @@ extension NumberFieldView {
 extension NumberFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        accessoryView.alpha = 0;
+        accessoryView.alpha = isEmpty() ? 0 : 1;
+        let endPosition = textField.endOfDocument;
+        textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition);
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {

--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -227,8 +227,6 @@ extension NumberFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         accessoryView.alpha = isEmpty() ? 0 : 1;
-        let endPosition = textField.endOfDocument;
-        textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition);
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -252,8 +252,6 @@ extension TextFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         accessoryView.alpha = isEmpty() ? 0 : 1;
-        let endPosition = textField.endOfDocument;
-        textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition);
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
@@ -276,8 +274,6 @@ extension TextFieldView: UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         accessoryView.alpha = isEmpty() ? 0 : 1;
-        let endPosition = textView.endOfDocument;
-        textView.selectedTextRange = textView.textRange(from: endPosition, to: endPosition);
     }
 
     func textViewDidChange(_ textView: UITextView) {

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -251,7 +251,9 @@ extension TextFieldView {
 extension TextFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        accessoryView.alpha = 0;
+        accessoryView.alpha = isEmpty() ? 0 : 1;
+        let endPosition = textField.endOfDocument;
+        textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition);
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
@@ -273,7 +275,9 @@ extension TextFieldView: UITextFieldDelegate {
 extension TextFieldView: UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
-        accessoryView.alpha = 0;
+        accessoryView.alpha = isEmpty() ? 0 : 1;
+        let endPosition = textView.endOfDocument;
+        textView.selectedTextRange = textView.textRange(from: endPosition, to: endPosition);
     }
 
     func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
- Fixed undo/redo icons not appearing when text/number boxes were de-selected then re-selected
- Bug with number box cursor not appearing, fixed to match text box