### PR TITLE
fix: Fixing undo/redo history function

### DIFF
--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -169,7 +169,8 @@ class NumberFieldView : BaseFieldView {
     }
 
     private func refreshUndoRedoButtons() {
-        undoButton.isEnabled = fieldUndoManager.canUndo
+        let hasUncommittedChange = textField.text != sessionStartValue
+        undoButton.isEnabled = fieldUndoManager.canUndo || hasUncommittedChange
         redoButton.isEnabled = fieldUndoManager.canRedo
     }
 
@@ -261,6 +262,7 @@ class NumberFieldView : BaseFieldView {
 extension NumberFieldView {
     @objc func textFieldDidChange() {
         showAccessoryView();
+        refreshUndoRedoButtons()
     }
 
     func showAccessoryView() {

--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -14,6 +14,10 @@ class NumberFieldView : BaseFieldView {
     private var min: NSNumber?;
     private var max: NSNumber?;
 
+    private let fieldUndoManager = UndoManager()
+    private var sessionStartValue: String?
+    private var isSessionActive = false
+
     lazy var helperText: String? = {
         var helper: String? = nil;
         if (self.min != nil && self.max != nil) {
@@ -148,12 +152,40 @@ class NumberFieldView : BaseFieldView {
         textField.text = number?.stringValue
     }
 
+    private func setUndoableText(_ newText: String?, oldText: String?) {
+        fieldUndoManager.registerUndo(withTarget: self) { target in
+            target.setUndoableText(oldText, oldText: newText)
+        }
+        setValue(newText)
+        let valid = isValid(enforceRequired: true, number: number)
+        setValid(valid)
+        delegate?.fieldValueChanged(field, value: number)
+    }
+
+    private func closeCurrentSession() {
+        guard isSessionActive else { return }
+        let currentText = textField.text
+        guard sessionStartValue != currentText else { return }
+        let number = formatter.number(from: currentText ?? "")
+        let valid = isValid(enforceRequired: true, number: number)
+        setValid(valid)
+        if valid {
+            setUndoableText(currentText, oldText: sessionStartValue)
+            sessionStartValue = currentText
+        } else {
+            self.number = number
+        }
+    }
+
     @objc func undoPressed() {
-        textField.undoManager?.undo();
+        closeCurrentSession()
+        fieldUndoManager.undo()
+        sessionStartValue = textField.text
     }
 
     @objc func redoPressed() {
-        textField.undoManager?.redo();
+        fieldUndoManager.redo()
+        sessionStartValue = textField.text
     }
 
     override func isEmpty() -> Bool {
@@ -226,6 +258,8 @@ extension NumberFieldView {
 extension NumberFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
+        sessionStartValue = textField.text
+        isSessionActive = true
         accessoryView.alpha = isEmpty() ? 0 : 1;
     }
 
@@ -234,15 +268,17 @@ extension NumberFieldView: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if let text: String = textField.text {
-            let number = formatter.number(from: text);
-            let valid = isValid(enforceRequired: true, number: number);
-            setValid(valid);
-            if (valid && (number == nil || (self.number?.stringValue != textField.text))) {
-                delegate?.fieldValueChanged(field, value: number);
-            }
-            self.number = number;
+        let newText = textField.text
+        let number = formatter.number(from: newText ?? "")
+        let valid = isValid(enforceRequired: true, number: number)
+        setValid(valid)
+        if valid, sessionStartValue != newText {
+            setUndoableText(newText, oldText: sessionStartValue)
+        } else {
+            self.number = number
         }
+        sessionStartValue = nil
+        isSessionActive = false
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/Mage/NumberFieldView.swift
+++ b/Mage/NumberFieldView.swift
@@ -16,7 +16,6 @@ class NumberFieldView : BaseFieldView {
 
     private let fieldUndoManager = UndoManager()
     private var sessionStartValue: String?
-    private var isSessionActive = false
 
     lazy var helperText: String? = {
         var helper: String? = nil;
@@ -43,28 +42,34 @@ class NumberFieldView : BaseFieldView {
         return formatter;
     }()
 
-    private lazy var accessoryView: UIToolbar = {
-        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 60);
-
-        let undoButton = UIBarButtonItem(
+    private lazy var undoButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
             image: UIImage(systemName: "arrow.uturn.backward"),
             style: .plain,
             target: self,
             action: #selector(undoPressed)
         );
-        undoButton.accessibilityLabel = "Undo";
+        button.accessibilityLabel = "Undo";
+        button.isEnabled = false;
+        return button;
+    }()
 
-        let redoButton = UIBarButtonItem(
+    private lazy var redoButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
             image: UIImage(systemName: "arrow.uturn.forward"),
             style: .plain,
             target: self,
             action: #selector(redoPressed)
         );
-        redoButton.accessibilityLabel = "Redo";
+        button.accessibilityLabel = "Redo";
+        button.isEnabled = false;
+        return button;
+    }()
 
+    private lazy var accessoryView: UIToolbar = {
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
+        toolbar.autoSetDimension(.height, toSize: 60);
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil);
-
         toolbar.items = [undoButton, redoButton, flexSpace];
         toolbar.alpha = 0;
         return toolbar;
@@ -160,10 +165,15 @@ class NumberFieldView : BaseFieldView {
         let valid = isValid(enforceRequired: true, number: number)
         setValid(valid)
         delegate?.fieldValueChanged(field, value: number)
+        refreshUndoRedoButtons()
+    }
+
+    private func refreshUndoRedoButtons() {
+        undoButton.isEnabled = fieldUndoManager.canUndo
+        redoButton.isEnabled = fieldUndoManager.canRedo
     }
 
     private func closeCurrentSession() {
-        guard isSessionActive else { return }
         let currentText = textField.text
         guard sessionStartValue != currentText else { return }
         let number = formatter.number(from: currentText ?? "")
@@ -179,13 +189,19 @@ class NumberFieldView : BaseFieldView {
 
     @objc func undoPressed() {
         closeCurrentSession()
-        fieldUndoManager.undo()
+        if fieldUndoManager.canUndo {
+            fieldUndoManager.undo()
+        }
         sessionStartValue = textField.text
+        refreshUndoRedoButtons()
     }
 
     @objc func redoPressed() {
-        fieldUndoManager.redo()
+        if fieldUndoManager.canRedo {
+            fieldUndoManager.redo()
+        }
         sessionStartValue = textField.text
+        refreshUndoRedoButtons()
     }
 
     override func isEmpty() -> Bool {
@@ -253,14 +269,17 @@ extension NumberFieldView {
             self.accessoryView.alpha = 1;
         }
     }
+
+    func shouldShowAccessoryView() -> Bool {
+        return !isEmpty() || fieldUndoManager.canUndo || fieldUndoManager.canRedo
+    }
 }
 
 extension NumberFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         sessionStartValue = textField.text
-        isSessionActive = true
-        accessoryView.alpha = isEmpty() ? 0 : 1;
+        accessoryView.alpha = shouldShowAccessoryView() ? 1 : 0;
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
@@ -278,7 +297,6 @@ extension NumberFieldView: UITextFieldDelegate {
             self.number = number
         }
         sessionStartValue = nil
-        isSessionActive = false
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -15,7 +15,6 @@ class TextFieldView : BaseFieldView {
 
     private let fieldUndoManager = UndoManager()
     private var sessionStartValue: String?
-    private var isSessionActive = false
 
     lazy var multilineTextField: MDCFilledTextArea  = {
         let multilineTextField = MDCFilledTextArea(frame: CGRect(x: 0, y: 0, width: 200, height: 100));
@@ -65,29 +64,35 @@ class TextFieldView : BaseFieldView {
         return textField;
     }()
 
-    private lazy var accessoryView: UIToolbar = {
-        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
-        toolbar.autoSetDimension(.height, toSize: 60);
-        // Adding undo & redo components
-        let undoButton = UIBarButtonItem(
+    // Undo/Redo components
+    private lazy var undoButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
             image: UIImage(systemName: "arrow.uturn.backward"),
             style: .plain,
             target: self,
             action: #selector(undoPressed)
         );
-        undoButton.accessibilityLabel = "Undo";
+        button.accessibilityLabel = "Undo";
+        button.isEnabled = false;
+        return button;
+    }()
 
-        let redoButton = UIBarButtonItem(
+    private lazy var redoButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
             image: UIImage(systemName: "arrow.uturn.forward"),
             style: .plain,
             target: self,
             action: #selector(redoPressed)
         );
-        redoButton.accessibilityLabel = "Redo";
+        button.accessibilityLabel = "Redo";
+        button.isEnabled = false;
+        return button;
+    }()
 
+    private lazy var accessoryView: UIToolbar = {
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44));
+        toolbar.autoSetDimension(.height, toSize: 60);
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil);
-
-        // New toolbar to host the two buttons
         toolbar.items = [undoButton, redoButton, flexSpace];
         toolbar.alpha = 0;
         return toolbar;
@@ -169,11 +174,16 @@ class TextFieldView : BaseFieldView {
             target in target.setUndoableValue(oldValue, oldValue: newValue)
         }
         setValue(newValue)
-        delegate?.fieldValueChanged(field, value: value)
+        delegate?.fieldValueChanged(field, value: newValue)
+        refreshUndoRedoButtons()
+    }
+
+    private func refreshUndoRedoButtons() {
+        undoButton.isEnabled = fieldUndoManager.canUndo
+        redoButton.isEnabled = fieldUndoManager.canRedo
     }
 
     private func closeCurrentSession() {
-        guard isSessionActive else { return }
         let currentText = multiline ? multilineTextField.textView.text : textField.text
         let newValue = currentText == "" ? nil : currentText
         if sessionStartValue != newValue {
@@ -186,6 +196,10 @@ class TextFieldView : BaseFieldView {
         self.value = value;
         if (self.multiline) {
             self.editMode ? (multilineTextField.textView.text = value) : (fieldValue.text = value);
+            if (self.editMode) {
+                multilineTextField.setNeedsLayout()
+                multilineTextField.layoutIfNeeded()
+            }
         } else {
             self.editMode ? (textField.text = value) : (fieldValue.text = value);
         }
@@ -253,15 +267,25 @@ extension TextFieldView {
         }
     }
 
+    func shouldShowAccessoryView() -> Bool {
+        return !isEmpty() || fieldUndoManager.canUndo || fieldUndoManager.canRedo
+    }
+
     @objc func undoPressed() {
         closeCurrentSession()
-        fieldUndoManager.undo()
+        if fieldUndoManager.canUndo {
+            fieldUndoManager.undo()
+        }
         sessionStartValue = value as? String
+        refreshUndoRedoButtons()
     }
 
     @objc func redoPressed() {
-        fieldUndoManager.redo()
+        if fieldUndoManager.canRedo {
+            fieldUndoManager.redo()
+        }
         sessionStartValue = value as? String
+        refreshUndoRedoButtons()
     }
 }
 
@@ -269,8 +293,7 @@ extension TextFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         sessionStartValue = value as? String
-        isSessionActive = true
-        accessoryView.alpha = isEmpty() ? 0 : 1;
+        accessoryView.alpha = shouldShowAccessoryView() ? 1 : 0;
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
@@ -283,7 +306,6 @@ extension TextFieldView: UITextFieldDelegate {
             setUndoableValue(newValue, oldValue: sessionStartValue)
         }
         sessionStartValue = nil
-        isSessionActive = false
     }
 }
 
@@ -292,8 +314,7 @@ extension TextFieldView: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
         sessionStartValue = value as? String
-        isSessionActive = true
-        accessoryView.alpha = isEmpty() ? 0 : 1;
+        accessoryView.alpha = shouldShowAccessoryView() ? 1 : 0;
     }
 
     func textViewDidChange(_ textView: UITextView) {
@@ -310,6 +331,5 @@ extension TextFieldView: UITextViewDelegate {
             setUndoableValue(newValue, oldValue: sessionStartValue)
         }
         sessionStartValue = nil
-        isSessionActive = false
     }
 }

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -13,6 +13,10 @@ class TextFieldView : BaseFieldView {
     private var multiline: Bool = false;
     private var keyboardType: UIKeyboardType = .default;
 
+    private let fieldUndoManager = UndoManager()
+    private var sessionStartValue: String?
+    private var isSessionActive = false
+
     lazy var multilineTextField: MDCFilledTextArea  = {
         let multilineTextField = MDCFilledTextArea(frame: CGRect(x: 0, y: 0, width: 200, height: 100));
         multilineTextField.textView.delegate = self;
@@ -160,6 +164,24 @@ class TextFieldView : BaseFieldView {
         self.setValue(value as? String);
     }
 
+    private func setUndoableValue(_ newValue: String?, oldValue: String?) {
+        fieldUndoManager.registerUndo(withTarget: self) {
+            target in target.setUndoableValue(oldValue, oldValue: newValue)
+        }
+        setValue(newValue)
+        delegate?.fieldValueChanged(field, value: value)
+    }
+
+    private func closeCurrentSession() {
+        guard isSessionActive else { return }
+        let currentText = multiline ? multilineTextField.textView.text : textField.text
+        let newValue = currentText == "" ? nil : currentText
+        if sessionStartValue != newValue {
+            setUndoableValue(newValue, oldValue: sessionStartValue)
+            sessionStartValue = newValue
+        }
+    }
+
     func setValue(_ value: String?) {
         self.value = value;
         if (self.multiline) {
@@ -232,25 +254,22 @@ extension TextFieldView {
     }
 
     @objc func undoPressed() {
-        if multiline {
-            multilineTextField.textView.undoManager?.undo();
-        } else {
-            textField.undoManager?.undo();
-        }
+        closeCurrentSession()
+        fieldUndoManager.undo()
+        sessionStartValue = value as? String
     }
 
     @objc func redoPressed() {
-        if multiline {
-            multilineTextField.textView.undoManager?.redo();
-        } else {
-            textField.undoManager?.redo();
-        }
+        fieldUndoManager.redo()
+        sessionStartValue = value as? String
     }
 }
 
 extension TextFieldView: UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
+        sessionStartValue = value as? String
+        isSessionActive = true
         accessoryView.alpha = isEmpty() ? 0 : 1;
     }
 
@@ -259,20 +278,20 @@ extension TextFieldView: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if (value as? String != textField.text) {
-            if (textField.text == "") {
-                value = nil;
-            } else {
-                value = textField.text;
-            }
-            delegate?.fieldValueChanged(field, value: value);
+        let newValue = textField.text == "" ? nil : textField.text
+        if sessionStartValue != newValue {
+            setUndoableValue(newValue, oldValue: sessionStartValue)
         }
+        sessionStartValue = nil
+        isSessionActive = false
     }
 }
 
 extension TextFieldView: UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
+        sessionStartValue = value as? String
+        isSessionActive = true
         accessoryView.alpha = isEmpty() ? 0 : 1;
     }
 
@@ -285,13 +304,11 @@ extension TextFieldView: UITextViewDelegate {
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        if (value as? String != textView.text) {
-            if (textView.text == "") {
-                value = nil;
-            } else {
-                value = textView.text;
-            }
-            delegate?.fieldValueChanged(field, value: value);
+        let newValue = textView.text == "" ? nil : textView.text
+        if sessionStartValue != newValue {
+            setUndoableValue(newValue, oldValue: sessionStartValue)
         }
+        sessionStartValue = nil
+        isSessionActive = false
     }
 }

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -179,7 +179,9 @@ class TextFieldView : BaseFieldView {
     }
 
     private func refreshUndoRedoButtons() {
-        undoButton.isEnabled = fieldUndoManager.canUndo
+        let currentText = multiline ? multilineTextField.textView.text : textField.text
+        let hasUncommittedChange = (currentText == "" ? nil : currentText) != sessionStartValue
+        undoButton.isEnabled = fieldUndoManager.canUndo || hasUncommittedChange
         redoButton.isEnabled = fieldUndoManager.canRedo
     }
 
@@ -258,6 +260,7 @@ extension TextFieldView {
 
     @objc func textFieldDidChange() {
         showAccessoryView();
+        refreshUndoRedoButtons()
     }
 
     func showAccessoryView() {
@@ -319,6 +322,7 @@ extension TextFieldView: UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
         showAccessoryView();
+        refreshUndoRedoButtons()
     }
 
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {

--- a/Mage/TextFieldView.swift
+++ b/Mage/TextFieldView.swift
@@ -290,6 +290,7 @@ extension TextFieldView: UITextFieldDelegate {
 extension TextFieldView: UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
+        textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
         sessionStartValue = value as? String
         isSessionActive = true
         accessoryView.alpha = isEmpty() ? 0 : 1;


### PR DESCRIPTION
- Eliminating original history mechanism that had no boundary between text fields
- Added boundaries to group text field instances, allowing user to undo/redo text in chunks based on input session versus as a collective history