### PR TITLE
fix(clamav): Improving clamav warning styling

### DIFF
--- a/Mage/AttachmentCell.swift
+++ b/Mage/AttachmentCell.swift
@@ -6,25 +6,58 @@
 import UIKit
 import Kingfisher
 import Persistence
+import MaterialComponents.MaterialRipple
 
 @objc class AttachmentCell: UICollectionViewCell {
-    
+
     private var button: MDCFloatingButton?;
     private var attachment: Attachment?;
-    
+    private var messageExpanded = false;
+    private var hintLabel: UILabel?;
+    private var hintLabelHeightConstraint: NSLayoutConstraint?;
+
     private lazy var imageView: AttachmentUIImageView = {
         let imageView: AttachmentUIImageView = AttachmentUIImageView(image: nil);
         imageView.configureForAutoLayout();
         imageView.clipsToBounds = true;
         return imageView;
     }();
-    
+
+    // Driven manually from touchesBegan/Ended/Cancelled below, same technique MDCCard uses -
+    // there's no gesture recognizer here to hang a ripple off of since taps on this cell are
+    // handled a few different ways (collection view selection, the failure-message toggle).
+    private lazy var rippleView: MDCRippleView = {
+        let ripple = MDCRippleView(forAutoLayout: ());
+        ripple.rippleStyle = .bounded;
+        ripple.isUserInteractionEnabled = false;
+        return ripple;
+    }();
+
     override init(frame: CGRect) {
         super.init(frame: frame);
         self.configureForAutoLayout();
         self.addSubview(imageView);
         imageView.autoPinEdgesToSuperviewEdges();
+        self.addSubview(rippleView);
+        rippleView.autoPinEdgesToSuperviewEdges();
         setNeedsLayout();
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event);
+        if let point = touches.first?.location(in: rippleView) {
+            rippleView.beginRippleTouchDown(at: point, animated: true, completion: nil);
+        }
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event);
+        rippleView.beginRippleTouchUp(animated: true, completion: nil);
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event);
+        rippleView.beginRippleTouchUp(animated: true, completion: nil);
     }
     
     required init?(coder: NSCoder) {
@@ -39,14 +72,41 @@ import Persistence
         }
         button?.removeFromSuperview();
         self.attachment = nil;
+        self.messageExpanded = false;
+        self.hintLabel = nil;
+        self.hintLabelHeightConstraint = nil;
         for recognizer in self.imageView.gestureRecognizers ?? [] {
             self.imageView.removeGestureRecognizer(recognizer);
         }
     }
 
-    @objc func showFailureMessage() {
-        if let window = self.window {
-            ToastView.show(message: attachment?.processingMessage ?? "Upload failed", in: window);
+    @objc func toggleFailureMessage() {
+        guard let hintLabel = hintLabel, let hintLabelHeightConstraint = hintLabelHeightConstraint else { return }
+        messageExpanded.toggle();
+        if (messageExpanded) {
+            hintLabel.text = attachment?.processingMessage ?? "Upload failed";
+            hintLabel.numberOfLines = 0;
+        } else {
+            hintLabel.text = "Tap for Details";
+            hintLabel.numberOfLines = 1;
+        }
+
+        let width = imageView.bounds.width - 16;
+        let collapsedHeight = hintLabel.font.pointSize;
+        if (messageExpanded && width > 0) {
+            let boundingHeight = (hintLabel.text as NSString?)?.boundingRect(
+                with: CGSize(width: width, height: .greatestFiniteMagnitude),
+                options: .usesLineFragmentOrigin,
+                attributes: [.font: hintLabel.font as Any],
+                context: nil
+            ).height ?? collapsedHeight;
+            hintLabelHeightConstraint.constant = ceil(boundingHeight);
+        } else {
+            hintLabelHeightConstraint.constant = collapsedHeight;
+        }
+
+        UIView.animate(withDuration: 0.2) {
+            self.layoutIfNeeded();
         }
     }
     
@@ -76,6 +136,7 @@ import Persistence
     @objc public func setImage(newAttachment: [String : AnyHashable], button: MDCFloatingButton? = nil, scheme: MDCContainerScheming? = nil) {
         layoutSubviews()
         self.button = button
+        self.rippleView.rippleColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.16) ?? UIColor.black.withAlphaComponent(0.16)
         self.imageView.tintColor = scheme?.colorScheme.onBackgroundColor.withAlphaComponent(0.4)
         self.imageView.contentMode = .scaleAspectFill
         self.imageView.kf.indicatorType = .none
@@ -132,17 +193,16 @@ import Persistence
         layoutSubviews();
         self.button = button;
         self.attachment = attachment;
+        self.rippleView.rippleColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.16) ?? UIColor.black.withAlphaComponent(0.16);
         self.imageView.kf.indicatorType = .none;
         self.imageView.tintColor = scheme?.colorScheme.onBackgroundColor.withAlphaComponent(0.4);
 
         if (attachment.isProcessingFailed) {
-            let iconConfig = UIImage.SymbolConfiguration(pointSize: 56, weight: .regular);
-            self.imageView.image = UIImage(systemName: "exclamationmark.circle.fill")?.withConfiguration(iconConfig);
-            self.imageView.tintColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87);
-            self.imageView.contentMode = .center;
+            self.imageView.image = nil;
             self.imageView.accessibilityLabel = "attachment \(attachment.name ?? "") upload failed";
             self.imageView.isUserInteractionEnabled = true;
-            self.imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(showFailureMessage)));
+            self.imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleFailureMessage)));
+            self.messageExpanded = false;
 
             let label = UILabel.newAutoLayout()
             label.text = "\(attachment.name ?? "")\nUpload Failed"
@@ -156,18 +216,35 @@ import Persistence
             label.autoPinEdge(toSuperviewEdge: .left, withInset: 8)
             label.autoPinEdge(toSuperviewEdge: .right, withInset: 8)
 
+            // A real subview pinned above `label`, rather than drawn via imageView's own
+            // contentMode = .center - that fixed the icon at a static point with no relationship
+            // to the labels below it, so it stayed put while the expanding message pushed the
+            // labels up into it. Anchoring the icon to label's top ties it into the same
+            // bottom-anchored chain as the labels, so the whole group moves together.
+            let iconConfig = UIImage.SymbolConfiguration(pointSize: 56, weight: .regular);
+            let icon = UIImageView.newAutoLayout()
+            icon.image = UIImage(systemName: "exclamationmark.circle.fill")?.withConfiguration(iconConfig);
+            icon.tintColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87);
+            icon.contentMode = .scaleAspectFit;
+            imageView.addSubview(icon);
+            icon.autoSetDimensions(to: CGSize(width: 56, height: 56));
+            icon.autoAlignAxis(.vertical, toSameAxisOf: imageView);
+            icon.autoPinEdge(.bottom, to: .top, of: label, withOffset: -8);
+
             let hintLabel = UILabel.newAutoLayout()
             hintLabel.text = "Tap for Details"
             hintLabel.textColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.4)
             hintLabel.font = UIFont.systemFont(ofSize: 10)
             hintLabel.textAlignment = .center
             hintLabel.numberOfLines = 1
-            hintLabel.autoSetDimension(.height, toSize: hintLabel.font.pointSize)
+            let hintLabelHeightConstraint = hintLabel.autoSetDimension(.height, toSize: hintLabel.font.pointSize)
             imageView.addSubview(hintLabel)
             hintLabel.autoPinEdge(.top, to: .bottom, of: label, withOffset: 2)
             hintLabel.autoPinEdge(toSuperviewEdge: .left, withInset: 8)
             hintLabel.autoPinEdge(toSuperviewEdge: .right, withInset: 8)
             hintLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: 16)
+            self.hintLabel = hintLabel;
+            self.hintLabelHeightConstraint = hintLabelHeightConstraint;
 
             self.backgroundColor = scheme?.colorScheme.backgroundColor
 

--- a/Mage/AttachmentCell.swift
+++ b/Mage/AttachmentCell.swift
@@ -15,6 +15,7 @@ import MaterialComponents.MaterialRipple
     private var messageExpanded = false;
     private var hintLabel: UILabel?;
     private var hintLabelHeightConstraint: NSLayoutConstraint?;
+    private var failureIcon: UIImageView?;
 
     private lazy var imageView: AttachmentUIImageView = {
         let imageView: AttachmentUIImageView = AttachmentUIImageView(image: nil);
@@ -75,6 +76,7 @@ import MaterialComponents.MaterialRipple
         self.messageExpanded = false;
         self.hintLabel = nil;
         self.hintLabelHeightConstraint = nil;
+        self.failureIcon = nil;
         for recognizer in self.imageView.gestureRecognizers ?? [] {
             self.imageView.removeGestureRecognizer(recognizer);
         }
@@ -83,6 +85,7 @@ import MaterialComponents.MaterialRipple
     @objc func toggleFailureMessage() {
         guard let hintLabel = hintLabel, let hintLabelHeightConstraint = hintLabelHeightConstraint else { return }
         messageExpanded.toggle();
+        failureIcon?.isHidden = messageExpanded;
         if (messageExpanded) {
             hintLabel.text = attachment?.processingMessage ?? "Upload failed";
             hintLabel.numberOfLines = 0;
@@ -204,32 +207,30 @@ import MaterialComponents.MaterialRipple
             self.imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleFailureMessage)));
             self.messageExpanded = false;
 
-            let label = UILabel.newAutoLayout()
-            label.text = "\(attachment.name ?? "")\nUpload Failed"
-            label.textColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-            label.font = scheme?.typographyScheme.overline
-            label.textAlignment = .center
-            label.numberOfLines = 2
-            label.lineBreakMode = .byTruncatingTail
-            label.autoSetDimension(.height, toSize: label.font.lineHeight * 2)
-            imageView.addSubview(label)
-            label.autoPinEdge(toSuperviewEdge: .left, withInset: 8)
-            label.autoPinEdge(toSuperviewEdge: .right, withInset: 8)
+            let titleLabel = UILabel.newAutoLayout()
+            titleLabel.text = "Upload Failed"
+            titleLabel.textColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87)
+            titleLabel.font = scheme?.typographyScheme.subtitle1
+            titleLabel.textAlignment = .center
+            titleLabel.numberOfLines = 1
+            titleLabel.autoSetDimension(.height, toSize: titleLabel.font.lineHeight)
 
-            // A real subview pinned above `label`, rather than drawn via imageView's own
-            // contentMode = .center - that fixed the icon at a static point with no relationship
-            // to the labels below it, so it stayed put while the expanding message pushed the
-            // labels up into it. Anchoring the icon to label's top ties it into the same
-            // bottom-anchored chain as the labels, so the whole group moves together.
+            let descriptionLabel = UILabel.newAutoLayout()
+            descriptionLabel.text = attachment.name
+            descriptionLabel.textColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+            descriptionLabel.font = scheme?.typographyScheme.caption
+            descriptionLabel.textAlignment = .center
+            descriptionLabel.numberOfLines = 1
+            descriptionLabel.lineBreakMode = .byTruncatingTail
+            descriptionLabel.autoSetDimension(.height, toSize: descriptionLabel.font.lineHeight)
+
             let iconConfig = UIImage.SymbolConfiguration(pointSize: 56, weight: .regular);
             let icon = UIImageView.newAutoLayout()
-            icon.image = UIImage(systemName: "exclamationmark.circle.fill")?.withConfiguration(iconConfig);
+            icon.image = UIImage(systemName: "exclamationmark.circle")?.withConfiguration(iconConfig);
             icon.tintColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87);
             icon.contentMode = .scaleAspectFit;
-            imageView.addSubview(icon);
             icon.autoSetDimensions(to: CGSize(width: 56, height: 56));
-            icon.autoAlignAxis(.vertical, toSameAxisOf: imageView);
-            icon.autoPinEdge(.bottom, to: .top, of: label, withOffset: -8);
+            self.failureIcon = icon;
 
             let hintLabel = UILabel.newAutoLayout()
             hintLabel.text = "Tap for Details"
@@ -238,13 +239,30 @@ import MaterialComponents.MaterialRipple
             hintLabel.textAlignment = .center
             hintLabel.numberOfLines = 1
             let hintLabelHeightConstraint = hintLabel.autoSetDimension(.height, toSize: hintLabel.font.pointSize)
-            imageView.addSubview(hintLabel)
-            hintLabel.autoPinEdge(.top, to: .bottom, of: label, withOffset: 2)
-            hintLabel.autoPinEdge(toSuperviewEdge: .left, withInset: 8)
-            hintLabel.autoPinEdge(toSuperviewEdge: .right, withInset: 8)
-            hintLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: 16)
             self.hintLabel = hintLabel;
             self.hintLabelHeightConstraint = hintLabelHeightConstraint;
+
+            // The whole group is centered as a single unit rather than anchored from any one
+            // fixed point, so it stays centered whether or not the icon is showing. UIStackView
+            // automatically collapses a hidden arranged subview's space, so hiding the icon on
+            // tap re-centers the remaining title/description/hint group for free.
+            let group = UIStackView(forAutoLayout: ());
+            group.axis = .vertical;
+            group.alignment = .center;
+            group.spacing = 2;
+            group.addArrangedSubview(icon);
+            group.setCustomSpacing(8, after: icon);
+            group.addArrangedSubview(titleLabel);
+            group.addArrangedSubview(descriptionLabel);
+            group.addArrangedSubview(hintLabel);
+            imageView.addSubview(group);
+            group.autoCenterInSuperview();
+
+            // Width constraints against imageView are only legal now that titleLabel/
+            // descriptionLabel/hintLabel actually share a view hierarchy with it (via group).
+            titleLabel.autoMatch(.width, to: .width, of: imageView, withOffset: -16)
+            descriptionLabel.autoMatch(.width, to: .width, of: imageView, withOffset: -16)
+            hintLabel.autoMatch(.width, to: .width, of: imageView, withOffset: -16)
 
             self.backgroundColor = scheme?.colorScheme.backgroundColor
 

--- a/Mage/AttachmentSlideshow.swift
+++ b/Mage/AttachmentSlideshow.swift
@@ -217,13 +217,48 @@ class AttachmentSlideShow: UIView {
             guard let imageView = imageView else {
                 return;
             }
+            for view in imageView.subviews {
+                view.removeFromSuperview();
+            }
             if (attachment.isProcessingFailed) {
-                let iconConfig = UIImage.SymbolConfiguration(pointSize: 56, weight: .regular);
-                imageView.image = UIImage(systemName: "exclamationmark.circle.fill")?.withConfiguration(iconConfig);
-                imageView.tintColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87);
+                imageView.image = nil;
                 imageView.contentMode = .center;
                 imageView.setAttachment(attachment: attachment);
                 imageView.accessibilityLabel = "attachment \(attachment.name ?? "") upload failed";
+
+                let iconConfig = UIImage.SymbolConfiguration(pointSize: 56, weight: .regular);
+                let icon = UIImageView.newAutoLayout();
+                icon.image = UIImage(systemName: "exclamationmark.circle")?.withConfiguration(iconConfig);
+                icon.tintColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87);
+                icon.contentMode = .scaleAspectFit;
+                icon.autoSetDimensions(to: CGSize(width: 56, height: 56));
+
+                let titleLabel = UILabel.newAutoLayout();
+                titleLabel.text = "Upload Failed";
+                titleLabel.textColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.87);
+                titleLabel.font = scheme?.typographyScheme.subtitle1;
+                titleLabel.textAlignment = .center;
+
+                let descriptionLabel = UILabel.newAutoLayout();
+                descriptionLabel.text = attachment.name;
+                descriptionLabel.textColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.6);
+                descriptionLabel.font = scheme?.typographyScheme.caption;
+                descriptionLabel.textAlignment = .center;
+                descriptionLabel.numberOfLines = 1;
+                descriptionLabel.lineBreakMode = .byTruncatingTail;
+
+                let group = UIStackView(forAutoLayout: ());
+                group.axis = .vertical;
+                group.alignment = .center;
+                group.spacing = 4;
+                group.addArrangedSubview(icon);
+                group.addArrangedSubview(titleLabel);
+                group.addArrangedSubview(descriptionLabel);
+                imageView.addSubview(group);
+                group.autoCenterInSuperview();
+                group.autoPinEdge(toSuperviewEdge: .left, withInset: 16, relation: .greaterThanOrEqual);
+                group.autoPinEdge(toSuperviewEdge: .right, withInset: 16, relation: .greaterThanOrEqual);
+
                 continue;
             }
             if (attachment.isUploading) {

--- a/Mage/ObservationCompactView.swift
+++ b/Mage/ObservationCompactView.swift
@@ -17,7 +17,6 @@ class ObservationCompactView: UIView {
     private var scheme: MDCContainerScheming?;
     private var cornerRadius:CGFloat = 0.0;
     private var includeAttachments: Bool = false;
-    private var totalAttachmentCount = 0;
 
     // Set by the containing cell/view so it can play its own tap feedback (e.g. a card's ripple)
     // at the right location before navigating - falls back to navigating directly if unset.
@@ -52,47 +51,6 @@ class ObservationCompactView: UIView {
         return actions;
     }();
 
-    private lazy var failedAttachmentLabel: UILabel = {
-        let label = UILabel.newAutoLayout()
-        label.textAlignment = .center
-        label.font = UIFont.systemFont(ofSize: 12, weight: .medium)
-        return label
-    }()
-
-    private lazy var failedAttachmentBadge: UIView = {
-        let badge = UIView.newAutoLayout()
-        badge.addSubview(failedAttachmentLabel)
-        failedAttachmentLabel.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 2, left: 8, bottom:2, right: 8))
-        badge.clipsToBounds = true
-        return badge
-    }()
-
-    // Row containing the failed attachment badge, placed under the carousel and above the
-    // coordinates row. Wraps the badge (leading/top/bottom only, no trailing) so the badge
-    // keeps hugging its own content width instead of stretching with the stack's .fill alignment.
-    private lazy var failedAttachmentRow: UIView = {
-        let row = UIView.newAutoLayout()
-        row.addSubview(failedAttachmentBadge)
-        failedAttachmentBadge.autoPinEdge(toSuperviewEdge: .leading, withInset: 8)
-        failedAttachmentBadge.autoPinEdge(toSuperviewEdge: .top, withInset: 8)
-        failedAttachmentBadge.autoPinEdge(toSuperviewEdge: .bottom, withInset: 8)
-        return row
-    }()
-
-    private lazy var attachmentCountLabel: UILabel = {
-        let label = UILabel.newAutoLayout()
-        label.textAlignment = .center
-        label.font = UIFont.systemFont(ofSize: 12, weight: .medium)
-        return label
-    }()
-
-    private lazy var attachmentCountBadge: UIView = {
-        let badge = UIView.newAutoLayout()
-        badge.addSubview(attachmentCountLabel)
-        attachmentCountLabel.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 8))
-        return badge
-    }()
-
     private lazy var attachmentSlideshow: AttachmentSlideShow = {
         let actions = AttachmentSlideShow();
         actions.isUserInteractionEnabled = true;
@@ -125,13 +83,6 @@ class ObservationCompactView: UIView {
         observationSummaryView.applyTheme(withScheme: scheme);
         observationActionsView.applyTheme(withScheme: scheme);
         attachmentSlideshow.applyTheme(withScheme: scheme);
-
-        let errorScheme = MAGEErrorScheme.scheme()
-        failedAttachmentBadge.backgroundColor = errorScheme.colorScheme.primaryColor.withAlphaComponent(0.12)
-        failedAttachmentLabel.textColor = errorScheme.colorScheme.primaryColor
-
-        attachmentCountBadge.backgroundColor = scheme?.colorScheme.onSurfaceColor.withAlphaComponent(0.85)
-        attachmentCountLabel.textColor = .white
     }
 
     public func configure(observation: Observation, scheme: MDCContainerScheming?, actionsDelegate: ObservationActionsDelegate?, attachmentSelectionDelegate: AttachmentSelectionDelegate?) {
@@ -148,7 +99,6 @@ class ObservationCompactView: UIView {
         attachmentSlideshow.applyTheme(withScheme: scheme)
 
         let activeAttachments = observation.attachments?.filter { !$0.markedForDeletion }
-        let failedCount = failedAttachmentCount(observation: observation)
         let hasAnyAttachment = includeAttachments && (activeAttachments?.count ?? 0) > 0
         if hasAnyAttachment {
             // No delegate here on purpose - tapping an attachment thumbnail in this list/card
@@ -159,42 +109,15 @@ class ObservationCompactView: UIView {
         attachmentSlideshow.isHidden = !hasAnyAttachment;
 
         applyTheme(withScheme: scheme);
-
-        if failedCount > 0 {
-            failedAttachmentLabel.text = failedCount > 1 ? "Attachments Failed - \(failedCount)" : "Attachment Failed"
-            failedAttachmentRow.isHidden = false
-        } else {
-            failedAttachmentRow.isHidden = true
-        }
-
-        totalAttachmentCount = activeAttachments?.count ?? 0
-        if totalAttachmentCount > 1 {
-            attachmentCountLabel.text = "1 of \(totalAttachmentCount)"
-            attachmentCountBadge.isHidden = false
-        } else {
-            attachmentCountBadge.isHidden = true
-        }
     }
 
     func prepareForReuse() {
         attachmentSlideshow.clear()
     }
 
-    func failedAttachmentCount(observation: Observation) -> Int {
-        return observation.attachments?.filter { !$0.markedForDeletion && $0.isProcessingFailed }.count ?? 0
-    }
-
     override func updateConstraints() {
         if (!didSetUpConstraints) {
             stackView.autoPinEdgesToSuperviewEdges();
-            failedAttachmentBadge.layer.cornerRadius = 12
-            attachmentCountBadge.layer.cornerRadius = 12
-            attachmentCountBadge.autoPinEdge(.bottom, to: .bottom, of: attachmentSlideshow, withOffset: -8)
-            attachmentCountBadge.autoPinEdge(.trailing, to: .trailing, of: attachmentSlideshow, withOffset: -8)
-            attachmentCountBadge.layer.shadowColor = UIColor.black.cgColor
-            attachmentCountBadge.layer.shadowOpacity = 0.25
-            attachmentCountBadge.layer.shadowRadius = 4
-            attachmentCountBadge.layer.shadowOffset = CGSize(width: 0, height: 2)
             didSetUpConstraints = true;
         }
         super.updateConstraints();
@@ -206,8 +129,6 @@ class ObservationCompactView: UIView {
             self.stackView.addArrangedSubview(importantView);
             self.stackView.addArrangedSubview(observationSummaryView);
             self.stackView.addArrangedSubview(attachmentSlideshow);
-            self.attachmentSlideshow.addSubview(attachmentCountBadge);
-            self.stackView.addArrangedSubview(failedAttachmentRow);
             self.stackView.addArrangedSubview(observationActionsView);
             // Explicit gesture rather than relying on the tap falling through the view
             // hierarchy to the card - AttachmentSlideShow and its internal scroll/stack views
@@ -215,10 +136,6 @@ class ObservationCompactView: UIView {
             // would otherwise dead-end instead of reaching the card's own tap handler.
             let attachmentSlideshowTap = UITapGestureRecognizer(target: self, action: #selector(attachmentSlideshowTapped(_:)));
             self.attachmentSlideshow.addGestureRecognizer(attachmentSlideshowTap);
-            self.attachmentSlideshow.onPageChanged = { [weak self] page in
-                guard let self = self else { return }
-                self.attachmentCountLabel.text = "\(page + 1) of \(self.totalAttachmentCount)"
-            }
             setNeedsUpdateConstraints();
             constructed = true;
         }

--- a/Mage/ObservationSummaryView.swift
+++ b/Mage/ObservationSummaryView.swift
@@ -145,13 +145,12 @@ class ObservationSummaryView: CommonSummaryView<Observation, ObservationActionsD
             }
         }
         
-        if (observation.error != nil) {
-            self.syncBadge.isHidden = observation.hasValidationError;
-            self.errorBadge.isHidden = !observation.hasValidationError;
-        } else {
-            self.syncBadge.isHidden = true;
-            self.errorBadge.isHidden = true;
-        }
+        let hasFailedAttachment = observation.attachments?.contains { !$0.markedForDeletion && $0.isProcessingFailed } ?? false
+        let showErrorBadge = (observation.error != nil && observation.hasValidationError) || hasFailedAttachment
+        let showSyncBadge = observation.error != nil && !observation.hasValidationError && !hasFailedAttachment
+
+        self.errorBadge.isHidden = !showErrorBadge;
+        self.syncBadge.isHidden = !showSyncBadge;
     }
     
     func handleUser(userName: String?) {


### PR DESCRIPTION
- Removing 'Attachment Failed' labeling to replace with a corner-flag at the top left
- Removing attachment count as bubbles to slide through already exist
- Removing snackbar error message for an expanding one